### PR TITLE
Indefinite text/byte-string write

### DIFF
--- a/cbor_serialization/writer.nim
+++ b/cbor_serialization/writer.nim
@@ -29,14 +29,11 @@ import
 export outputs, format, types, DefaultFlavor
 
 type
-  CollectionKind = enum
-    Array
-    Object
-
   CborWriter*[Flavor = DefaultFlavor] = object
     stream: OutputStream
-    stack: seq[CollectionKind] # Stack that keeps track of nested arrays/objects
+    stack: seq[CborMajor] # Stack that keeps track of nested collections
     wantName: bool # The next output should be a name (for an object member)
+    wantBytes, wantByte: bool # The next output should be text/bytes
 
 Cbor.setWriter CborWriter, PreferredOutput = seq[byte]
 
@@ -101,7 +98,13 @@ proc writeHead(
     discard
 
 func inObject(w: CborWriter): bool =
-  w.stack.len > 0 and w.stack[^1] == Object
+  w.stack.len > 0 and w.stack[^1] == CborMajor.Map
+
+func inText(w: CborWriter): bool =
+  w.stack.len > 0 and w.stack[^1] == CborMajor.Text
+
+func inBytes(w: CborWriter): bool =
+  w.stack.len > 0 and w.stack[^1] == CborMajor.Bytes
 
 proc beginElement(w: var CborWriter) =
   ## Start writing an array element or the value part of an object member.
@@ -111,10 +114,14 @@ proc beginElement(w: var CborWriter) =
   ## The framework takes care to call `beginElement`/`endElement` as necessary
   ## as part of `writeValue` and `streamElement`.
   doAssert not w.wantName
+  doAssert not w.wantBytes
+  doAssert not w.wantByte
 
 proc endElement(w: var CborWriter) =
   ## Matching `end` call for `beginElement`
   w.wantName = w.inObject
+  w.wantBytes = w.inText or w.inBytes
+  w.wantByte = false
 
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.1-2.12
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.2.2
@@ -134,12 +141,11 @@ proc beginObject*(w: var CborWriter, length = -1) {.raises: [IOError].} =
     w.stream.write initialByte(CborMajor.Map, cborMinorIndef)
 
   w.wantName = true
-
-  w.stack.add(Object)
+  w.stack.add CborMajor.Map
 
 proc endObject*(w: var CborWriter, stopCode = true) {.raises: [IOError].} =
   ## Finish writing an object started with `beginObject`.
-  doAssert w.stack.pop() == Object
+  doAssert w.stack.pop() == CborMajor.Map
 
   if stopCode:
     w.stream.write cborBreakStopCode
@@ -158,16 +164,85 @@ proc beginArray*(w: var CborWriter, length = -1) {.raises: [IOError].} =
   else:
     w.stream.write initialByte(CborMajor.Array, cborMinorIndef)
 
-  w.stack.add(Array)
+  w.stack.add CborMajor.Array
 
 proc endArray*(w: var CborWriter, stopCode = true) {.raises: [IOError].} =
   ## Finish writing a Cbor array started with `beginArray`.
-  doAssert w.stack.pop() == Array
+  doAssert w.stack.pop() == CborMajor.Array
 
   if stopCode:
     w.stream.write cborBreakStopCode
 
   w.endElement()
+
+proc beginStringLike(
+    w: var CborWriter, length: int, kind: CborMajor
+) {.raises: [IOError].} =
+  doAssert kind in {CborMajor.Text, CborMajor.Bytes}
+  doAssert not w.wantBytes or length >= 0, "cannot nest indefinite text/bytes"
+  doAssert not w.wantByte, "cannot nest definite text/bytes"
+  doAssert not w.inText or kind == CborMajor.Text
+  doAssert not w.inBytes or kind == CborMajor.Bytes
+
+  w.wantBytes = false
+  w.wantByte = false
+  w.beginElement()
+
+  if length >= 0:
+    w.writeHead(kind, length.uint64)
+    w.wantByte = true
+  else:
+    w.stream.write initialByte(kind, cborMinorIndef)
+    w.wantBytes = true
+
+  w.stack.add kind
+
+proc beginText*(w: var CborWriter, length = -1) {.raises: [IOError].} =
+  beginStringLike(w, length, CborMajor.Text)
+
+proc beginBytes*(w: var CborWriter, length = -1) {.raises: [IOError].} =
+  beginStringLike(w, length, CborMajor.Bytes)
+
+proc endStringLike(w: var CborWriter, stopCode: bool) {.raises: [IOError].} =
+  doAssert w.stack.pop() in {CborMajor.Text, CborMajor.Bytes}
+
+  if stopCode:
+    w.stream.write cborBreakStopCode
+
+  w.endElement()
+
+proc endBytes*(w: var CborWriter, stopCode = true) {.raises: [IOError].} =
+  endStringLike(w, stopCode)
+
+proc endText*(w: var CborWriter, stopCode = true) {.raises: [IOError].} =
+  endStringLike(w, stopCode)
+
+proc writeByte*(w: var CborWriter, x: byte) {.raises: [IOError].} =
+  doAssert w.wantByte
+  w.stream.write(x)
+
+proc writeChar*(w: var CborWriter, x: char) {.raises: [IOError].} =
+  w.writeByte byte(x)
+
+template writeText*(w: var CborWriter, length: int, body: untyped) =
+  ## Write a Cbor text; use ``writeChar`` to write the characters.
+  beginText(w, length)
+  body
+  endText(w, length < 0)
+
+template writeText*(w: var CborWriter, body: untyped) =
+  writeText(w, -1):
+    body
+
+template writeBytes*(w: var CborWriter, length: int, body: untyped) =
+  ## Write a Cbor bytes; use ``writeByte`` to write the bytes.
+  beginBytes(w, length)
+  body
+  endBytes(w, length < 0)
+
+template writeBytes*(w: var CborWriter, body: untyped) =
+  writeBytes(w, -1):
+    body
 
 template streamElement*(w: var CborWriter, streamVar: untyped, body: untyped) =
   ## Write an element giving direct access to the underlying stream - each
@@ -183,12 +258,16 @@ template streamElement*(w: var CborWriter, streamVar: untyped, body: untyped) =
 
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.1-2.8
 proc write*(w: var CborWriter, val: openArray[char]) {.raises: [IOError].} =
+  doAssert not w.wantBytes or w.inText
+  w.wantBytes = false
   w.streamElement(s):
     w.writeHead(CborMajor.Text, val.len.uint64)
     s.write(val)
 
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.1-2.6
 proc write*(w: var CborWriter, val: seq[byte]) {.raises: [IOError].} =
+  doAssert not w.wantBytes or w.inBytes
+  w.wantBytes = false
   w.streamElement(s):
     w.writeHead(CborMajor.Bytes, val.len.uint64)
     s.write(val)
@@ -200,18 +279,26 @@ proc write*(w: var CborWriter, val: CborSimpleValue) {.raises: [IOError].} =
 
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.1-2.2
 # https://www.rfc-editor.org/rfc/rfc8949#name-pseudocode-for-encoding-a-s
-proc write*[T: SomeSignedInt](w: var CborWriter, val: T) {.raises: [IOError].} =
+proc writeInt(w: var CborWriter, val: SomeSignedInt) {.raises: [IOError].} =
   w.streamElement(_):
-    var ui = uint64(val shr (sizeof(T) * 8 - 1))
+    var ui = uint64(val shr (sizeof(typeof(val)) * 8 - 1))
     let mt = CborMajor(ui and 1)
     ui = ui xor uint64(val)
     assert mt in {CborMajor.Unsigned, CborMajor.Negative}
     w.writeHead(mt, ui)
 
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.1-2.2
-proc write*[T: SomeUnsignedInt](w: var CborWriter, val: T) {.raises: [IOError].} =
+proc writeUint(w: var CborWriter, val: SomeUnsignedInt) {.raises: [IOError].} =
   w.streamElement(_):
     w.writeHead(CborMajor.Unsigned, val.uint64)
+
+# TODO https://github.com/nim-lang/Nim/issues/25172
+proc write*[T: SomeInteger](w: var CborWriter, val: T) {.raises: [IOError].} =
+  when T is SomeSignedInt:
+    writeInt(w, val)
+  else:
+    static: doAssert T is SomeUnsignedInt
+    writeUint(w, val)
 
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.3
 proc write*(w: var CborWriter, val: SomeFloat) {.raises: [IOError].} =

--- a/tests/test_writer.nim
+++ b/tests/test_writer.nim
@@ -8,7 +8,8 @@
 # those terms.
 
 import
-  unittest2,
+  pkg/unittest2,
+  pkg/stew/byteutils,
   ./utils,
   ../cbor_serialization/pkg/results,
   ../cbor_serialization/std/options,
@@ -252,3 +253,214 @@ suite "Test writer":
     let v = MyCbor.encode(One)
     check v.hex == "0x634f6e65"
     checkCbor v, "One"
+
+type
+  DefinText = distinct string
+  IndefText = distinct seq[string]
+  DefinBytes = distinct seq[byte]
+  IndefBytes = distinct seq[seq[byte]]
+
+createCborFlavor StringLikeCbor,
+  automaticObjectSerialization = false, automaticPrimitivesSerialization = false
+
+proc writeValue*(
+    w: var StringLikeCbor.Writer, val: DefinText
+) {.gcsafe, raises: [IOError].} =
+  writeText(w, val.string.len):
+    for x in val.string:
+      w.writeChar(x)
+
+proc writeValue*(
+    w: var StringLikeCbor.Writer, val: IndefText
+) {.gcsafe, raises: [IOError].} =
+  writeText(w):
+    for chunk in seq[string](val):
+      writeText(w, chunk.len):
+        for x in chunk:
+          w.writeChar(x)
+
+proc writeValue*(
+    w: var StringLikeCbor.Writer, val: seq[string]
+) {.gcsafe, raises: [IOError].} =
+  writeText(w):
+    for chunk in val:
+      w.write(chunk)
+
+proc writeValue*(
+    w: var StringLikeCbor.Writer, val: DefinBytes
+) {.gcsafe, raises: [IOError].} =
+  writeBytes(w, seq[byte](val).len):
+    for x in seq[byte](val):
+      w.writeByte(x)
+
+proc writeValue*(
+    w: var StringLikeCbor.Writer, val: IndefBytes
+) {.gcsafe, raises: [IOError].} =
+  writeBytes(w):
+    for chunk in seq[seq[byte]](val):
+      writeBytes(w, chunk.len):
+        for x in chunk:
+          w.writeByte(x)
+
+proc writeValue*(
+    w: var StringLikeCbor.Writer, val: seq[seq[byte]]
+) {.gcsafe, raises: [IOError].} =
+  writeBytes(w):
+    for chunk in val:
+      w.write(chunk)
+
+func toWriter(output: var OutputStream): CborWriter[DefaultFlavor] =
+  output = memoryOutput()
+  CborWriter[DefaultFlavor].init(output)
+
+suite "Test write text":
+  test "definite":
+    let cbor = StringLikeCbor.encode("abc".DefinText)
+    check cbor.hex == "0x63616263"
+    checkCbor cbor, "abc"
+
+  test "indefinite 1 chunk":
+    let cbor = StringLikeCbor.encode(@["abc"].IndefText)
+    check cbor.hex == "0x7f63616263ff"
+    checkCbor cbor, "abc"
+
+  test "indefinite 3 chunks":
+    let cbor = StringLikeCbor.encode(@["a", "bc", "def"].IndefText)
+    check cbor.hex == "0x7f616162626363646566ff"
+    checkCbor cbor, "abcdef"
+
+  test "indefinite with writeValue":
+    let cbor = StringLikeCbor.encode(@["a", "bc", "def"])
+    check cbor.hex == "0x7f616162626363646566ff"
+    checkCbor cbor, "abcdef"
+
+  test "indefinite nesting not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeText(w):
+      expect AssertionDefect:
+        writeText(w):
+          w.writeChar('a')
+
+  test "definite nesting not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeText(w, 1):
+      expect AssertionDefect:
+        writeText(w, 1):
+          w.writeChar('a')
+
+  test "indefinite in definite not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeText(w, 1):
+      expect AssertionDefect:
+        writeText(w):
+          w.writeChar('a')
+
+  test "bytes in indefinite text not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeText(w):
+      expect AssertionDefect:
+        writeBytes(w, 1):
+          w.writeByte('a'.byte)
+
+  test "bytes in definite text not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeText(w, 1):
+      expect AssertionDefect:
+        writeBytes(w, 1):
+          w.writeByte('a'.byte)
+
+  test "non-text in indefinite text not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeText(w):
+      expect AssertionDefect:
+        w.write(123)
+
+  test "non-text in definite text not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeText(w, 1):
+      expect AssertionDefect:
+        w.write(123)
+
+suite "Test write byte string":
+  test "definite":
+    let cbor = StringLikeCbor.encode("abc".toBytes.DefinBytes)
+    check cbor.hex == "0x43616263"
+    checkCbor cbor, "abc".toBytes
+
+  test "indefinite 1 chunk":
+    let cbor = StringLikeCbor.encode(@["abc".toBytes].IndefBytes)
+    check cbor.hex == "0x5f43616263ff"
+    checkCbor cbor, "abc".toBytes
+
+  test "indefinite 3 chunks":
+    let val = @["a".toBytes, "bc".toBytes, "def".toBytes]
+    let cbor = StringLikeCbor.encode(val.IndefBytes)
+    check cbor.hex == "0x5f416142626343646566ff"
+    checkCbor cbor, "abcdef".toBytes
+
+  test "indefinite with byte chunks":
+    let val = @["a".toBytes, "bc".toBytes, "def".toBytes]
+    let cbor = StringLikeCbor.encode(val)
+    check cbor.hex == "0x5f416142626343646566ff"
+    checkCbor cbor, "abcdef".toBytes
+
+  test "indefinite nesting not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeBytes(w):
+      expect AssertionDefect:
+        writeBytes(w):
+          w.writeByte('a'.byte)
+
+  test "definite nesting not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeBytes(w, 1):
+      expect AssertionDefect:
+        writeBytes(w, 1):
+          w.writeByte('a'.byte)
+
+  test "indefinite in definite not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeBytes(w, 1):
+      expect AssertionDefect:
+        writeBytes(w):
+          w.writeByte('a'.byte)
+
+  test "text in indefinite bytes not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeBytes(w):
+      expect AssertionDefect:
+        writeText(w, 1):
+          w.writeChar('a')
+
+  test "text in definite bytes not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeBytes(w, 1):
+      expect AssertionDefect:
+        writeText(w, 1):
+          w.writeChar('a')
+
+  test "non-bytes in indefinite bytes not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeBytes(w):
+      expect AssertionDefect:
+        w.write(123)
+
+  test "non-bytes in definite bytes not allowed":
+    var output: OutputStream
+    var w = toWriter output
+    writeBytes(w, 1):
+      expect AssertionDefect:
+        w.write(123)


### PR DESCRIPTION
Changes:

- `writeText` and `writeBytes` to write text/bytes chunks and byte-by-byte

Found this API was missing while [testing nim-web3 usage](https://github.com/status-im/nim-web3/pull/225).