### PR TITLE
Perf improvement

### DIFF
--- a/cbor_serialization/parser.nim
+++ b/cbor_serialization/parser.nim
@@ -134,7 +134,7 @@ proc parseStringLike[T: string or seq[byte]](
   var L = p.lenMaybe()
   var i = 0
   parseStringLikeImpl(p, majorExpected, limit, strLen):
-    if L > -1:  # can prealloc safely
+    if L > -1: # can prealloc safely
       val.setLen val.len.uint64 + strLen
   do:
     if L > -1:

--- a/cbor_serialization/parser.nim
+++ b/cbor_serialization/parser.nim
@@ -96,10 +96,7 @@ template parseStringLikeImpl(
     body
 
 template parseStringLikeImpl(
-    p: var CborParser,
-    majorExpected: CborMajor,
-    limit: int,
-    strLen, body: untyped,
+    p: var CborParser, majorExpected: CborMajor, limit: int, strLen, body: untyped
 ) =
   let L = lenMaybe(p)
   var i = 0'u64
@@ -192,10 +189,7 @@ template parseArrayLikeImpl(
   exitNestedStructure(p)
 
 template parseArrayLikeImpl(
-    p: var CborParser,
-    majorExpected: CborMajor,
-    limit: int,
-    arrLen, body: untyped,
+    p: var CborParser, majorExpected: CborMajor, limit: int, arrLen, body: untyped
 ) =
   let L = p.lenMaybe()
   var i = 0'u64
@@ -216,9 +210,7 @@ template parseArrayLike(
 
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.1-2.10
 template parseArrayImpl(p: var CborParser, arrLen, body: untyped) =
-  parseArrayLikeImpl(
-    p, CborMajor.Array, p.conf.arrayElementsLimit, arrLen, body
-  )
+  parseArrayLikeImpl(p, CborMajor.Array, p.conf.arrayElementsLimit, arrLen, body)
 
 template parseArray(p: var CborParser, idx, body: untyped) =
   var idx = 0

--- a/cbor_serialization/parser.nim
+++ b/cbor_serialization/parser.nim
@@ -66,7 +66,7 @@ func `$`(major: CborMajor): string =
   of CborMajor.Tag: "tag"
   of CborMajor.SimpleOrFloat: "simple/float/break"
 
-proc lenMaybe(p: var CborParser): int {.raises: [IOError].} =
+proc lenMaybe*(p: var CborParser): int {.raises: [IOError].} =
   ## Return -1 if cannot calculate the len
   let L = p.stream.len()
   if L.isSome():
@@ -131,12 +131,17 @@ proc parseStringLike[T: string or seq[byte]](
 ) {.raises: [IOError, CborReaderError].} =
   type ElmType = typeof val[0]
   val.setLen 0
+  var L = p.lenMaybe()
   var i = 0
   parseStringLikeImpl(p, majorExpected, limit, strLen):
-    val.setLen val.len.uint64 + strLen
+    if L > -1:  # can prealloc safely
+      val.setLen val.len.uint64 + strLen
   do:
-    val[i] = p.read ElmType
-    inc i
+    if L > -1:
+      val[i] = p.read ElmType
+      inc i
+    else:
+      val.add p.read ElmType
 
 proc parseStringLike(
     p: var CborParser, majorExpected: CborMajor, limit: int, val: var CborVoid

--- a/cbor_serialization/parser.nim
+++ b/cbor_serialization/parser.nim
@@ -352,7 +352,9 @@ proc parseRawHead(
   val.add c
   discard readMinorValue(p, val, c.minor)
 
-template parseRawArrayLikeImpl(p: var CborParser, val: var CborBytes, rawLen, prelude, body: untyped) =
+template parseRawArrayLikeImpl(
+    p: var CborParser, val: var CborBytes, rawLen, prelude, body: untyped
+) =
   assert p.peek().major in {CborMajor.Array, CborMajor.Map}
   let c = p.read()
   val.add c
@@ -387,7 +389,9 @@ template parseRawArrayLike(
     body
   exitNestedStructure(p)
 
-template parseRawStringLikeImpl(p: var CborParser, val: var CborBytes, rawLen, prelude, body: untyped) =
+template parseRawStringLikeImpl(
+    p: var CborParser, val: var CborBytes, rawLen, prelude, body: untyped
+) =
   assert p.peek().major in {CborMajor.Bytes, CborMajor.Text}
   let c = p.read()
   val.add c

--- a/cbor_serialization/parser.nim
+++ b/cbor_serialization/parser.nim
@@ -23,6 +23,9 @@ template read(p: CborParser): byte =
     p.raiseUnexpectedValue("unexpected eof")
   inputs.read(p.stream)
 
+template read(p: CborParser, T: type): untyped =
+  read(p).T
+
 func minorLen(minor: uint8): int =
   assert minor in cborMinorLens
   if minor < cborMinorLen1:
@@ -63,54 +66,89 @@ func `$`(major: CborMajor): string =
   of CborMajor.Tag: "tag"
   of CborMajor.SimpleOrFloat: "simple/float/break"
 
+proc lenMaybe(p: var CborParser): int {.raises: [IOError].} =
+  ## Return -1 if cannot calculate the len
+  let L = p.stream.len()
+  if L.isSome():
+    L.get().int
+  else:
+    -1
+
 template parseStringLikeImpl(
-    p: var CborParser, majorExpected: CborMajor, body: untyped
+    p: var CborParser, majorExpected: CborMajor, strLen, prelude, body: untyped
 ) =
   let c = p.read()
   if c.major != majorExpected:
     p.raiseUnexpectedValue($majorExpected, $c.major)
+  var strLen = 0'u64
   if c.minor == cborMinorIndef:
     # https://www.rfc-editor.org/rfc/rfc8949#section-3.2.3
     while p.peek() != cborBreakStopCode:
       let c2 = p.read()
       if c2.major != majorExpected:
         p.raiseUnexpectedValue($majorExpected, $c2.major)
-      for _ in 0 ..< readMinorValue(p, c2.minor):
+      strLen = readMinorValue(p, c2.minor)
+      prelude
+      for _ in 0 ..< strLen:
         body
     discard p.read() # stop code
   else:
     # https://www.rfc-editor.org/rfc/rfc8949#section-3-3.2
-    for _ in 0 ..< readMinorValue(p, c.minor):
+    strLen = readMinorValue(p, c.minor)
+    prelude
+    for _ in 0 ..< strLen:
       body
+
+template parseStringLikeImpl(
+    p: var CborParser,
+    majorExpected: CborMajor,
+    limit: int,
+    strLen, prelude, body: untyped,
+) =
+  let L = lenMaybe(p)
+  var i = 0'u64
+  parseStringLikeImpl(p, majorExpected, strLen):
+    i += strLen
+    if L > -1 and i > L.uint64:
+      p.raiseNotEnoughBytes("not enough bytes to read")
+    if limit > 0 and i > limit.uint64:
+      p.raiseUnexpectedValue($majorExpected & " length limit reached")
+
+    prelude
+  do:
+    body
 
 iterator parseStringLikeIt(
     p: var CborParser, majorExpected: CborMajor, limit: int
 ): byte {.inline, raises: [IOError, CborReaderError].} =
-  var strLen = 0
-  parseStringLikeImpl(p, majorExpected):
-    inc strLen
-    if limit > 0 and strLen > limit:
-      p.raiseUnexpectedValue($majorExpected & " length limit reached")
+  parseStringLikeImpl(p, majorExpected, limit, strLen):
+    discard strLen
+  do:
     yield p.read()
 
-proc parseStringLike[T](
+proc parseStringLike[T: string or seq[byte]](
     p: var CborParser, majorExpected: CborMajor, limit: int, val: var T
 ) {.raises: [IOError, CborReaderError].} =
-  when T isnot (string or seq[byte] or CborVoid):
-    {.fatal: "`parseStringLike` only accepts string or `seq[byte]` or `CborVoid`".}
-  for v in parseStringLikeIt(p, majorExpected, limit):
-    when T is CborVoid:
-      discard v
-    elif T is string:
-      val.add v.char
-    else:
-      val.add v
+  type ElmType = typeof val[0]
+  val.setLen 0
+  var i = 0
+  parseStringLikeImpl(p, majorExpected, limit, strLen):
+    val.setLen val.len.uint64 + strLen
+  do:
+    val[i] = p.read ElmType
+    inc i
+
+proc parseStringLike(
+    p: var CborParser, majorExpected: CborMajor, limit: int, val: var CborVoid
+) {.raises: [IOError, CborReaderError].} =
+  for _ in parseStringLikeIt(p, majorExpected, limit):
+    discard val
 
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.1-2.6
 proc parseByteString[T](
     p: var CborParser, limit: int, val: var T
 ) {.raises: [IOError, CborReaderError].} =
-  parseStringLike[T](p, CborMajor.Bytes, limit, val)
+  parseStringLike(p, CborMajor.Bytes, limit, val)
 
 proc parseByteString[T](
     p: var CborParser, val: var T
@@ -121,7 +159,7 @@ proc parseByteString[T](
 proc parseString[T](
     p: var CborParser, limit: int, val: var T
 ) {.raises: [IOError, CborReaderError].} =
-  parseStringLike[T](p, CborMajor.Text, limit, val)
+  parseStringLike(p, CborMajor.Text, limit, val)
 
 proc parseString[T](
     p: var CborParser, val: var T
@@ -136,38 +174,71 @@ template enterNestedStructure(p: CborParser) =
 template exitNestedStructure(p: CborParser) =
   dec p.currDepth
 
-template parseArrayLike(p: var CborParser, majorExpected: CborMajor, body: untyped) =
+template parseArrayLikeImpl(
+    p: var CborParser, majorExpected: CborMajor, arrLen, prelude, body: untyped
+) =
   enterNestedStructure(p)
   let c = p.read()
   if c.major != majorExpected:
     p.raiseUnexpectedValue($majorExpected, $c.major)
+  var arrLen = 0'u64
   if c.minor == cborMinorIndef:
     # https://www.rfc-editor.org/rfc/rfc8949#section-3.2.2
     while p.peek() != cborBreakStopCode:
+      arrLen = 1'u64
+      prelude
       body
     discard p.read() # stop code
   else:
     # https://www.rfc-editor.org/rfc/rfc8949#section-3-3.2
-    for _ in 0 ..< readMinorValue(p, c.minor):
+    arrLen = readMinorValue(p, c.minor)
+    prelude
+    for _ in 0 ..< arrLen:
       body
   exitNestedStructure(p)
 
+template parseArrayLikeImpl(
+    p: var CborParser,
+    majorExpected: CborMajor,
+    limit: int,
+    arrLen, prelude, body: untyped,
+) =
+  let L = p.lenMaybe()
+  var i = 0'u64
+  parseArrayLikeImpl(p, majorExpected, arrLen):
+    i += arrLen
+    if L > -1 and i > L.uint64:
+      p.raiseNotEnoughBytes("not enough bytes to read")
+    if limit > 0 and i > limit.uint64:
+      p.raiseUnexpectedValue($majorExpected & " length limit reached")
+
+    prelude
+  do:
+    body
+
+template parseArrayLikeImpl(
+    p: var CborParser, majorExpected: CborMajor, limit: int, body: untyped
+) =
+  parseArrayLikeImpl(p, majorExpected, limit, arrLen):
+    discard arrLen
+  do:
+    body
+
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.1-2.10
+template parseArray(p: var CborParser, arrLen, prelude, body: untyped) =
+  parseArrayLikeImpl(
+    p, CborMajor.Array, p.conf.arrayElementsLimit, arrLen, prelude, body
+  )
+
 template parseArray(p: var CborParser, idx, body: untyped) =
-  var idx {.inject.} = 0
-  parseArrayLike(p, CborMajor.Array):
-    if p.conf.arrayElementsLimit > 0 and idx + 1 > p.conf.arrayElementsLimit:
-      p.raiseUnexpectedValue("`arrayElementsLimit` reached")
+  var idx = 0
+  parseArrayLikeImpl(p, CborMajor.Array, p.conf.arrayElementsLimit):
     body
     inc idx
 
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.1-2.12
 template parseObjectImpl(p: var CborParser, skipNullFields, keyAction, body: untyped) =
-  var numElem = 0
-  parseArrayLike(p, CborMajor.Map):
-    inc numElem
-    if p.conf.objectFieldsLimit > 0 and numElem > p.conf.objectFieldsLimit:
-      p.raiseUnexpectedValue("`objectFieldsLimit` reached")
+  parseArrayLikeImpl(p, CborMajor.Map, p.conf.objectFieldsLimit):
     keyAction
     when skipNullFields:
       if r.parser.cborKind() in {CborValueKind.Null, CborValueKind.Undefined}:
@@ -179,7 +250,7 @@ template parseObjectImpl(p: var CborParser, skipNullFields, keyAction, body: unt
 
 template parseObject(p: var CborParser, skipNullFields, key, body: untyped) =
   parseObjectImpl(p, skipNullFields):
-    var key {.inject.} = ""
+    var key = ""
     p.parseString(key)
   do:
     body
@@ -281,16 +352,21 @@ proc parseRawHead(
   val.add c
   discard readMinorValue(p, val, c.minor)
 
-template parseRawArrayLikeImpl(p: var CborParser, val: var CborBytes, body: untyped) =
+template parseRawArrayLikeImpl(p: var CborParser, val: var CborBytes, rawLen, prelude, body: untyped) =
   assert p.peek().major in {CborMajor.Array, CborMajor.Map}
   let c = p.read()
   val.add c
+  var rawLen = 0'u64
   if c.minor == cborMinorIndef:
     while p.peek() != cborBreakStopCode:
+      rawLen = 1'u64
+      prelude
       body
     val.add p.read() # stop code
   else:
-    for _ in 0 ..< readMinorValue(p, val, c.minor):
+    rawLen = readMinorValue(p, val, c.minor)
+    prelude
+    for _ in 0 ..< rawLen:
       body
 
 template parseRawArrayLike(
@@ -299,29 +375,38 @@ template parseRawArrayLike(
   assert p.peek().major in {CborMajor.Array, CborMajor.Map}
   enterNestedStructure(p)
   let c = p.peek()
-  var rawLen = 0
-  parseRawArrayLikeImpl(p, val):
-    inc rawLen
-    if limit > 0 and rawLen > limit:
+  let L = p.lenMaybe()
+  var i = 0'u64
+  parseRawArrayLikeImpl(p, val, rawLen):
+    i += rawLen
+    if L > -1 and i > L.uint64:
+      p.raiseNotEnoughBytes("not enough bytes to read")
+    if limit > 0 and i > limit.uint64:
       p.raiseUnexpectedValue($c.major & " length reached")
+  do:
     body
   exitNestedStructure(p)
 
-template parseRawStringLikeImpl(p: var CborParser, val: var CborBytes, body: untyped) =
+template parseRawStringLikeImpl(p: var CborParser, val: var CborBytes, rawLen, prelude, body: untyped) =
   assert p.peek().major in {CborMajor.Bytes, CborMajor.Text}
   let c = p.read()
   val.add c
+  var rawLen = 0'u64
   if c.minor == cborMinorIndef:
     while p.peek() != cborBreakStopCode:
       let c2 = p.read()
       val.add c2
       if c2.major != c.major:
         p.raiseUnexpectedValue($c.major, $c2.major)
-      for _ in 0 ..< readMinorValue(p, val, c2.minor):
+      rawLen = readMinorValue(p, val, c2.minor)
+      prelude
+      for _ in 0 ..< rawLen:
         body
     val.add p.read() # stop code
   else:
-    for _ in 0 ..< readMinorValue(p, val, c.minor):
+    rawLen = readMinorValue(p, val, c.minor)
+    prelude
+    for _ in 0 ..< rawLen:
       body
 
 proc parseRawStringLike(
@@ -329,11 +414,16 @@ proc parseRawStringLike(
 ) {.raises: [IOError, CborReaderError].} =
   assert p.peek().major in {CborMajor.Bytes, CborMajor.Text}
   let c = p.peek()
-  var rawLen = 0
-  parseRawStringLikeImpl(p, val):
-    inc rawLen
-    if limit > 0 and rawLen > limit:
+  let L = p.lenMaybe()
+  var i = 0'u64
+  parseRawStringLikeImpl(p, val, rawLen):
+    i += rawLen
+    if L > -1 and i > L.uint64:
+      p.raiseNotEnoughBytes("not enough bytes to read")
+    if limit > 0 and i > limit.uint64:
       p.raiseUnexpectedValue($c.major & " length reached")
+    # XXX prealloc
+  do:
     val.add p.read()
 
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.1
@@ -449,6 +539,9 @@ template parseArray*(r: var CborReader, body: untyped) =
 
 template parseArray*(r: var CborReader, idx, body: untyped) =
   parseArray(r.parser, idx, body)
+
+template parseArray*(r: var CborReader, arrLen, prelude, body: untyped) =
+  parseArray(r.parser, arrLen, prelude, body)
 
 template skipNullFields(r: CborReader): untyped =
   mixin skipsNullFields

--- a/cbor_serialization/parser.nim
+++ b/cbor_serialization/parser.nim
@@ -75,7 +75,7 @@ proc lenMaybe*(p: var CborParser): int {.raises: [IOError].} =
     -1
 
 template parseStringLikeImpl(
-    p: var CborParser, majorExpected: CborMajor, strLen, prelude, body: untyped
+    p: var CborParser, majorExpected: CborMajor, strLen, body: untyped
 ) =
   let c = p.read()
   if c.major != majorExpected:
@@ -88,22 +88,18 @@ template parseStringLikeImpl(
       if c2.major != majorExpected:
         p.raiseUnexpectedValue($majorExpected, $c2.major)
       strLen = readMinorValue(p, c2.minor)
-      prelude
-      for _ in 0 ..< strLen:
-        body
+      body
     discard p.read() # stop code
   else:
     # https://www.rfc-editor.org/rfc/rfc8949#section-3-3.2
     strLen = readMinorValue(p, c.minor)
-    prelude
-    for _ in 0 ..< strLen:
-      body
+    body
 
 template parseStringLikeImpl(
     p: var CborParser,
     majorExpected: CborMajor,
     limit: int,
-    strLen, prelude, body: untyped,
+    strLen, body: untyped,
 ) =
   let L = lenMaybe(p)
   var i = 0'u64
@@ -113,18 +109,14 @@ template parseStringLikeImpl(
       p.raiseNotEnoughBytes("not enough bytes to read")
     if limit > 0 and i > limit.uint64:
       p.raiseUnexpectedValue($majorExpected & " length limit reached")
-
-    prelude
-  do:
     body
 
 iterator parseStringLikeIt(
     p: var CborParser, majorExpected: CborMajor, limit: int
 ): byte {.inline, raises: [IOError, CborReaderError].} =
   parseStringLikeImpl(p, majorExpected, limit, strLen):
-    discard strLen
-  do:
-    yield p.read()
+    for _ in 0 ..< strLen:
+      yield p.read()
 
 proc parseStringLike[T: string or seq[byte]](
     p: var CborParser, majorExpected: CborMajor, limit: int, val: var T
@@ -136,12 +128,12 @@ proc parseStringLike[T: string or seq[byte]](
   parseStringLikeImpl(p, majorExpected, limit, strLen):
     if L > -1: # can prealloc safely
       val.setLen val.len.uint64 + strLen
-  do:
-    if L > -1:
-      val[i] = p.read ElmType
-      inc i
+      for _ in 0 ..< strLen:
+        val[i] = p.read ElmType
+        inc i
     else:
-      val.add p.read ElmType
+      for _ in 0 ..< strLen:
+        val.add p.read ElmType
 
 proc parseStringLike(
     p: var CborParser, majorExpected: CborMajor, limit: int, val: var CborVoid
@@ -180,7 +172,7 @@ template exitNestedStructure(p: CborParser) =
   dec p.currDepth
 
 template parseArrayLikeImpl(
-    p: var CborParser, majorExpected: CborMajor, arrLen, prelude, body: untyped
+    p: var CborParser, majorExpected: CborMajor, arrLen, body: untyped
 ) =
   enterNestedStructure(p)
   let c = p.read()
@@ -191,22 +183,19 @@ template parseArrayLikeImpl(
     # https://www.rfc-editor.org/rfc/rfc8949#section-3.2.2
     while p.peek() != cborBreakStopCode:
       arrLen = 1'u64
-      prelude
       body
     discard p.read() # stop code
   else:
     # https://www.rfc-editor.org/rfc/rfc8949#section-3-3.2
     arrLen = readMinorValue(p, c.minor)
-    prelude
-    for _ in 0 ..< arrLen:
-      body
+    body
   exitNestedStructure(p)
 
 template parseArrayLikeImpl(
     p: var CborParser,
     majorExpected: CborMajor,
     limit: int,
-    arrLen, prelude, body: untyped,
+    arrLen, body: untyped,
 ) =
   let L = p.lenMaybe()
   var i = 0'u64
@@ -216,34 +205,31 @@ template parseArrayLikeImpl(
       p.raiseNotEnoughBytes("not enough bytes to read")
     if limit > 0 and i > limit.uint64:
       p.raiseUnexpectedValue($majorExpected & " length limit reached")
-
-    prelude
-  do:
     body
 
-template parseArrayLikeImpl(
+template parseArrayLike(
     p: var CborParser, majorExpected: CborMajor, limit: int, body: untyped
 ) =
   parseArrayLikeImpl(p, majorExpected, limit, arrLen):
-    discard arrLen
-  do:
-    body
+    for _ in 0 ..< arrLen:
+      body
 
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.1-2.10
-template parseArray(p: var CborParser, arrLen, prelude, body: untyped) =
+template parseArrayImpl(p: var CborParser, arrLen, body: untyped) =
   parseArrayLikeImpl(
-    p, CborMajor.Array, p.conf.arrayElementsLimit, arrLen, prelude, body
+    p, CborMajor.Array, p.conf.arrayElementsLimit, arrLen, body
   )
 
 template parseArray(p: var CborParser, idx, body: untyped) =
   var idx = 0
-  parseArrayLikeImpl(p, CborMajor.Array, p.conf.arrayElementsLimit):
-    body
-    inc idx
+  parseArrayImpl(p, arrLen):
+    for _ in 0 ..< arrLen:
+      body
+      inc idx
 
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.1-2.12
 template parseObjectImpl(p: var CborParser, skipNullFields, keyAction, body: untyped) =
-  parseArrayLikeImpl(p, CborMajor.Map, p.conf.objectFieldsLimit):
+  parseArrayLike(p, CborMajor.Map, p.conf.objectFieldsLimit):
     keyAction
     when skipNullFields:
       if r.parser.cborKind() in {CborValueKind.Null, CborValueKind.Undefined}:
@@ -358,7 +344,7 @@ proc parseRawHead(
   discard readMinorValue(p, val, c.minor)
 
 template parseRawArrayLikeImpl(
-    p: var CborParser, val: var CborBytes, rawLen, prelude, body: untyped
+    p: var CborParser, val: var CborBytes, rawLen, body: untyped
 ) =
   assert p.peek().major in {CborMajor.Array, CborMajor.Map}
   let c = p.read()
@@ -367,14 +353,11 @@ template parseRawArrayLikeImpl(
   if c.minor == cborMinorIndef:
     while p.peek() != cborBreakStopCode:
       rawLen = 1'u64
-      prelude
       body
     val.add p.read() # stop code
   else:
     rawLen = readMinorValue(p, val, c.minor)
-    prelude
-    for _ in 0 ..< rawLen:
-      body
+    body
 
 template parseRawArrayLike(
     p: var CborParser, val: var CborBytes, limit: int, body: untyped
@@ -390,12 +373,12 @@ template parseRawArrayLike(
       p.raiseNotEnoughBytes("not enough bytes to read")
     if limit > 0 and i > limit.uint64:
       p.raiseUnexpectedValue($c.major & " length reached")
-  do:
-    body
+    for _ in 0 ..< rawLen:
+      body
   exitNestedStructure(p)
 
 template parseRawStringLikeImpl(
-    p: var CborParser, val: var CborBytes, rawLen, prelude, body: untyped
+    p: var CborParser, val: var CborBytes, rawLen, body: untyped
 ) =
   assert p.peek().major in {CborMajor.Bytes, CborMajor.Text}
   let c = p.read()
@@ -408,15 +391,11 @@ template parseRawStringLikeImpl(
       if c2.major != c.major:
         p.raiseUnexpectedValue($c.major, $c2.major)
       rawLen = readMinorValue(p, val, c2.minor)
-      prelude
-      for _ in 0 ..< rawLen:
-        body
+      body
     val.add p.read() # stop code
   else:
     rawLen = readMinorValue(p, val, c.minor)
-    prelude
-    for _ in 0 ..< rawLen:
-      body
+    body
 
 proc parseRawStringLike(
     p: var CborParser, val: var CborBytes, limit: int
@@ -432,8 +411,8 @@ proc parseRawStringLike(
     if limit > 0 and i > limit.uint64:
       p.raiseUnexpectedValue($c.major & " length reached")
     # XXX prealloc
-  do:
-    val.add p.read()
+    for _ in 0 ..< rawLen:
+      val.add p.read()
 
 # https://www.rfc-editor.org/rfc/rfc8949#section-3.1
 proc cborKind*(p: CborParser): CborValueKind {.raises: [IOError, CborReaderError].} =
@@ -549,8 +528,8 @@ template parseArray*(r: var CborReader, body: untyped) =
 template parseArray*(r: var CborReader, idx, body: untyped) =
   parseArray(r.parser, idx, body)
 
-template parseArray*(r: var CborReader, arrLen, prelude, body: untyped) =
-  parseArray(r.parser, arrLen, prelude, body)
+template parseArray2*(r: var CborReader, arrLen, body: untyped) =
+  parseArrayImpl(r.parser, arrLen, body)
 
 template skipNullFields(r: CborReader): untyped =
   mixin skipsNullFields

--- a/cbor_serialization/reader_desc.nim
+++ b/cbor_serialization/reader_desc.nim
@@ -35,6 +35,8 @@ type
 
   CborUnexpectedValueError* = object of CborReaderError
 
+  CborNotEnoughBytesError* = object of CborUnexpectedValueError
+
   CborIncompleteObjectError* = object of CborReaderError
     objectType: cstring
 
@@ -59,6 +61,9 @@ method formatMsg*(err: ref CborIntOverflowError, filename: string): string =
 method formatMsg*(err: ref CborUnexpectedValueError, filename: string): string =
   fmt"{filename}({err.pos}) {err.msg}"
 
+method formatMsg*(err: ref CborNotEnoughBytesError, filename: string): string =
+  fmt"{filename}({err.pos}) {err.msg}"
+
 method formatMsg*(err: ref CborIncompleteObjectError, filename: string): string =
   fmt"{filename}({err.pos}) Not all required fields were specified when reading '{err.objectType}'"
 
@@ -77,6 +82,14 @@ func raiseUnexpectedValue*(
 
 template raiseUnexpectedValue*(r: CborReader, msg: string) =
   raiseUnexpectedValue(r.parser, msg)
+
+func raiseNotEnoughBytes*(
+    p: CborParser, msg: string
+) {.noreturn, raises: [CborReaderError].} =
+  var ex = new CborNotEnoughBytesError
+  ex.pos = p.stream.pos
+  ex.msg = msg
+  raise ex
 
 func raiseIntOverflow*(
     p: CborParser, absIntVal: BiggestUInt, isNegative: bool

--- a/cbor_serialization/reader_impl.nim
+++ b/cbor_serialization/reader_impl.nim
@@ -362,7 +362,7 @@ proc read*[T](
   var L = r.parser.lenMaybe()
   var i = 0
   r.parseArray(arrLen):
-    if L > -1:  # can prealloc safely
+    if L > -1: # can prealloc safely
       value.setLen value.len.uint64 + arrLen
   do:
     if L > -1:

--- a/cbor_serialization/reader_impl.nim
+++ b/cbor_serialization/reader_impl.nim
@@ -361,16 +361,17 @@ proc read*[T](
   value.setLen 0
   var L = r.parser.lenMaybe()
   var i = 0
-  r.parseArray(arrLen):
+  r.parseArray2(arrLen):
     if L > -1: # can prealloc safely
       value.setLen value.len.uint64 + arrLen
-  do:
-    if L > -1:
-      readValue(r, value[i])
+      for _ in 0 ..< arrLen:
+        readValue(r, value[i])
+        inc i
     else:
-      value.setLen value.len + 1
-      readValue(r, value[i])
-    inc i
+      for _ in 0 ..< arrLen:
+        value.setLen value.len + 1
+        readValue(r, value[i])
+        inc i
 
 proc read*[T: array](
     r: var CborReader, value: var T

--- a/cbor_serialization/reader_impl.nim
+++ b/cbor_serialization/reader_impl.nim
@@ -358,10 +358,13 @@ proc read*[T](
 ) {.raises: [SerializationError, IOError].} =
   mixin readValue
 
-  r.parseArray:
-    let lastPos = value.len
-    value.setLen(lastPos + 1)
-    readValue(r, value[lastPos])
+  value.setLen 0
+  var i = 0
+  r.parseArray(arrLen):
+    value.setLen value.len.uint64 + arrLen
+  do:
+    readValue(r, value[i])
+    inc i
 
 proc read*[T: array](
     r: var CborReader, value: var T

--- a/cbor_serialization/reader_impl.nim
+++ b/cbor_serialization/reader_impl.nim
@@ -359,11 +359,17 @@ proc read*[T](
   mixin readValue
 
   value.setLen 0
+  var L = r.parser.lenMaybe()
   var i = 0
   r.parseArray(arrLen):
-    value.setLen value.len.uint64 + arrLen
+    if L > -1:  # can prealloc safely
+      value.setLen value.len.uint64 + arrLen
   do:
-    readValue(r, value[i])
+    if L > -1:
+      readValue(r, value[i])
+    else:
+      value.setLen value.len + 1
+      readValue(r, value[i])
     inc i
 
 proc read*[T: array](

--- a/cbor_serialization/writer.nim
+++ b/cbor_serialization/writer.nim
@@ -244,7 +244,7 @@ template streamElement*(w: var CborWriter, streamVar: untyped, body: untyped) =
   ## high-level helpers as these already perform the element tracking done in
   ## `streamElement`.
   w.beginElement()
-  let streamVar = w.stream
+  template streamVar: untyped = w.stream
   body
   w.endElement()
 

--- a/cbor_serialization/writer.nim
+++ b/cbor_serialization/writer.nim
@@ -244,7 +244,9 @@ template streamElement*(w: var CborWriter, streamVar: untyped, body: untyped) =
   ## high-level helpers as these already perform the element tracking done in
   ## `streamElement`.
   w.beginElement()
-  template streamVar: untyped = w.stream
+  template streamVar(): untyped =
+    w.stream
+
   body
   w.endElement()
 

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -11,7 +11,7 @@
 
 import
   test_spec, test_serialization, test_simple_value, test_cbor_flavor, test_parser,
-  test_reader, test_writer, test_valueref, test_cbor_raw, test_std, test_overloads,
+  test_reader, test_writer, test_valueref, test_cbor_raw, test_malformed, test_std, test_overloads,
   test_edn, test_cddl_parser, test_cddl_gen
 
 template importBigints() =

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -11,8 +11,8 @@
 
 import
   test_spec, test_serialization, test_simple_value, test_cbor_flavor, test_parser,
-  test_reader, test_writer, test_valueref, test_cbor_raw, test_malformed, test_std, test_overloads,
-  test_edn, test_cddl_parser, test_cddl_gen
+  test_reader, test_writer, test_valueref, test_cbor_raw, test_malformed, test_std,
+  test_overloads, test_edn, test_cddl_parser, test_cddl_gen
 
 template importBigints() =
   import bigints

--- a/tests/test_malformed.nim
+++ b/tests/test_malformed.nim
@@ -1,0 +1,49 @@
+# cbor-serialization
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import unittest2, ./utils, ../cbor_serialization
+
+suite "Malformed data tests":
+  test "Byte array of len int64.high div 2":
+    # byte string of len (int64.high / 2) and content "01020304"
+    let cbor = "0x5b3fffffffffffffff01020304".unhex
+    expect CborNotEnoughBytesError:
+      discard Cbor.decode(cbor, CborValueRef)
+    expect CborNotEnoughBytesError:
+      discard Cbor.decode(cbor, seq[byte])
+    expect CborNotEnoughBytesError:
+      discard Cbor.decode(cbor, CborBytes)
+
+  test "String of len int64.high div 2":
+    # string of len (int64.high / 2) and content "abcd"
+    let cbor = "0x7b3fffffffffffffff61626364".unhex
+    expect CborNotEnoughBytesError:
+      discard Cbor.decode(cbor, CborValueRef)
+    expect CborNotEnoughBytesError:
+      discard Cbor.decode(cbor, string)
+    expect CborNotEnoughBytesError:
+      discard Cbor.decode(cbor, CborBytes)
+
+  test "Array of len int64.high div 2":
+    # array of len (int64.high / 2) and content "01020304"
+    let cbor = "0x9b3fffffffffffffff01020304".unhex
+    expect CborNotEnoughBytesError:
+      discard Cbor.decode(cbor, CborValueRef)
+    expect CborNotEnoughBytesError:
+      discard Cbor.decode(cbor, seq[int])
+    expect CborNotEnoughBytesError:
+      discard Cbor.decode(cbor, CborBytes)
+
+  test "Map of len int64.high div 2":
+    # map of len (int64.high / 2) and content "01020304"
+    let cbor = "bb3fffffffffffffff01020304".unhex
+    expect CborNotEnoughBytesError:
+      discard Cbor.decode(cbor, CborValueRef)
+    expect CborNotEnoughBytesError:
+      discard Cbor.decode(cbor, CborBytes)

--- a/tests/test_malformed.nim
+++ b/tests/test_malformed.nim
@@ -9,36 +9,35 @@
 
 import unittest2, ./utils, ../cbor_serialization
 
+proc checkAny(cbor: seq[byte]) =
+  expect CborNotEnoughBytesError:
+    discard Cbor.decode(cbor, CborValueRef)
+  expect CborNotEnoughBytesError:
+    discard Cbor.decode(cbor, CborBytes)
+  expect CborNotEnoughBytesError:
+    discard Cbor.decode(cbor, CborVoid)
+
 suite "Malformed data tests":
   test "Byte array of len int64.high div 2":
     # byte string of len (int64.high / 2) and content "01020304"
     let cbor = "0x5b3fffffffffffffff01020304".unhex
     expect CborNotEnoughBytesError:
-      discard Cbor.decode(cbor, CborValueRef)
-    expect CborNotEnoughBytesError:
       discard Cbor.decode(cbor, seq[byte])
-    expect CborNotEnoughBytesError:
-      discard Cbor.decode(cbor, CborBytes)
+    checkAny(cbor)
 
   test "String of len int64.high div 2":
     # string of len (int64.high / 2) and content "abcd"
     let cbor = "0x7b3fffffffffffffff61626364".unhex
     expect CborNotEnoughBytesError:
-      discard Cbor.decode(cbor, CborValueRef)
-    expect CborNotEnoughBytesError:
       discard Cbor.decode(cbor, string)
-    expect CborNotEnoughBytesError:
-      discard Cbor.decode(cbor, CborBytes)
+    checkAny(cbor)
 
   test "Array of len int64.high div 2":
     # array of len (int64.high / 2) and content "01020304"
     let cbor = "0x9b3fffffffffffffff01020304".unhex
     expect CborNotEnoughBytesError:
-      discard Cbor.decode(cbor, CborValueRef)
-    expect CborNotEnoughBytesError:
       discard Cbor.decode(cbor, seq[int])
-    expect CborNotEnoughBytesError:
-      discard Cbor.decode(cbor, CborBytes)
+    checkAny(cbor)
 
   test "Map of len int64.high div 2":
     type Obj = object
@@ -47,8 +46,5 @@ suite "Malformed data tests":
     # map of len (int64.high / 2) and content "01020304"
     let cbor = "bb3fffffffffffffff01020304".unhex
     expect CborNotEnoughBytesError:
-      discard Cbor.decode(cbor, CborValueRef)
-    expect CborNotEnoughBytesError:
       discard Cbor.decode(cbor, Obj)
-    expect CborNotEnoughBytesError:
-      discard Cbor.decode(cbor, CborBytes)
+    checkAny(cbor)

--- a/tests/test_malformed.nim
+++ b/tests/test_malformed.nim
@@ -17,7 +17,7 @@ proc checkTruncatedAny(cbor: seq[byte]) =
   expect CborNotEnoughBytesError:
     discard Cbor.decode(cbor, CborVoid)
 
-suite "Malformed data tests":
+suite "Malformed truncated data":
   test "Byte array of len int64.high div 2":
     # byte string of len (int64.high / 2) and content "01020304"
     let cbor = "0x5b3fffffffffffffff01020304".unhex

--- a/tests/test_malformed.nim
+++ b/tests/test_malformed.nim
@@ -41,9 +41,14 @@ suite "Malformed data tests":
       discard Cbor.decode(cbor, CborBytes)
 
   test "Map of len int64.high div 2":
+    type Obj = object
+      a: int
+
     # map of len (int64.high / 2) and content "01020304"
     let cbor = "bb3fffffffffffffff01020304".unhex
     expect CborNotEnoughBytesError:
       discard Cbor.decode(cbor, CborValueRef)
+    expect CborNotEnoughBytesError:
+      discard Cbor.decode(cbor, Obj)
     expect CborNotEnoughBytesError:
       discard Cbor.decode(cbor, CborBytes)

--- a/tests/test_malformed.nim
+++ b/tests/test_malformed.nim
@@ -9,7 +9,7 @@
 
 import unittest2, ./utils, ../cbor_serialization
 
-proc checkAny(cbor: seq[byte]) =
+proc checkTruncatedAny(cbor: seq[byte]) =
   expect CborNotEnoughBytesError:
     discard Cbor.decode(cbor, CborValueRef)
   expect CborNotEnoughBytesError:
@@ -23,21 +23,21 @@ suite "Malformed data tests":
     let cbor = "0x5b3fffffffffffffff01020304".unhex
     expect CborNotEnoughBytesError:
       discard Cbor.decode(cbor, seq[byte])
-    checkAny(cbor)
+    checkTruncatedAny(cbor)
 
   test "String of len int64.high div 2":
     # string of len (int64.high / 2) and content "abcd"
     let cbor = "0x7b3fffffffffffffff61626364".unhex
     expect CborNotEnoughBytesError:
       discard Cbor.decode(cbor, string)
-    checkAny(cbor)
+    checkTruncatedAny(cbor)
 
   test "Array of len int64.high div 2":
     # array of len (int64.high / 2) and content "01020304"
     let cbor = "0x9b3fffffffffffffff01020304".unhex
     expect CborNotEnoughBytesError:
       discard Cbor.decode(cbor, seq[int])
-    checkAny(cbor)
+    checkTruncatedAny(cbor)
 
   test "Map of len int64.high div 2":
     type Obj = object
@@ -47,4 +47,4 @@ suite "Malformed data tests":
     let cbor = "bb3fffffffffffffff01020304".unhex
     expect CborNotEnoughBytesError:
       discard Cbor.decode(cbor, Obj)
-    checkAny(cbor)
+    checkTruncatedAny(cbor)


### PR DESCRIPTION
Changes:

- Preallocs definite strings (cbor string/byte-string) and seq (cbor array).
- Special care taken to validate length before alloc.
- Add `CborNotEnoughBytes` for testing purposes.

TODO:

- [x] prealloc only when stream size length is known
- [x] check there are enough bytes to read before prealloc
- [ ] Overflow check for uint64 value sum passed to setLen
- [x] Tests cbor encoded len int64.high does not OOM
- [x] https://github.com/status-im/nim-faststreams/pull/86 companion PR (bottleneck)
- [ ] Do "write" sanity checks on debug mode and some `cborSerializationWriteChecks` define; follow up to https://github.com/vacp2p/nim-cbor-serialization/pull/6

this is ~3x faster on Orc and ~2x faster on Refc