### PR TITLE
Avoid mixin ambiguity errors

### DIFF
--- a/cbor_serialization/format.nim
+++ b/cbor_serialization/format.nim
@@ -192,6 +192,8 @@ template createCborFlavor*(
     allowUnknownFields = true,
     skipNullFields = false,
 ) {.dirty.} =
+  bind EnumRepresentation
+
   when declared(SerializationFormat): # Earlier versions lack mimeTypeValue
     createFlavor(Cbor, FlavorName, mimeTypeValue)
   else:
@@ -224,7 +226,7 @@ template createCborFlavor*(
   template flavorSkipNullFields*(T: type FlavorName): bool =
     skipNullFields
 
-  var `FlavorName EnumRep` {.compileTime.} = EnumAsString
+  var `FlavorName EnumRep` {.compileTime.} = EnumRepresentation.EnumAsString
   template flavorEnumRep*(T: type FlavorName): EnumRepresentation =
     `FlavorName EnumRep`
 

--- a/cbor_serialization/format.nim
+++ b/cbor_serialization/format.nim
@@ -192,7 +192,7 @@ template createCborFlavor*(
     allowUnknownFields = true,
     skipNullFields = false,
 ) {.dirty.} =
-  bind EnumRepresentation, Reader, Writer, createFlavor, Cbor
+  bind EnumRepresentation, Cbor
 
   when declared(SerializationFormat): # Earlier versions lack mimeTypeValue
     createFlavor(Cbor, FlavorName, mimeTypeValue)

--- a/cbor_serialization/format.nim
+++ b/cbor_serialization/format.nim
@@ -192,7 +192,7 @@ template createCborFlavor*(
     allowUnknownFields = true,
     skipNullFields = false,
 ) {.dirty.} =
-  bind EnumRepresentation
+  bind EnumRepresentation, Reader, Writer, createFlavor, Cbor
 
   when declared(SerializationFormat): # Earlier versions lack mimeTypeValue
     createFlavor(Cbor, FlavorName, mimeTypeValue)

--- a/cbor_serialization/format.nim
+++ b/cbor_serialization/format.nim
@@ -192,7 +192,7 @@ template createCborFlavor*(
     allowUnknownFields = true,
     skipNullFields = false,
 ) {.dirty.} =
-  bind EnumRepresentation, Cbor
+  bind EnumRepresentation
 
   when declared(SerializationFormat): # Earlier versions lack mimeTypeValue
     createFlavor(Cbor, FlavorName, mimeTypeValue)

--- a/cbor_serialization/parser.nim
+++ b/cbor_serialization/parser.nim
@@ -460,6 +460,9 @@ template skipNullFields(r: CborReader): untyped =
 template parseObject*(r: var CborReader, key: untyped, body: untyped) =
   parseObject(r.parser, r.skipNullFields, key, body)
 
+template parseObjectWithoutSkip*(r: var CborReader, key: untyped, body: untyped) =
+  parseObject(r.parser, false, key, body)
+
 template parseTag*(p: var CborReader, tag: untyped, body: untyped) =
   parseTag(r.parser, tag, body)
 

--- a/cbor_serialization/pkg/results.nim
+++ b/cbor_serialization/pkg/results.nim
@@ -13,7 +13,7 @@ import pkg/results, ../../cbor_serialization/[reader, writer]
 
 export results
 
-template shouldWriteObjectField*[T](field: Result[T, void]): bool =
+template shouldWriteObjectField*[T](F: type Cbor, field: Result[T, void]): bool =
   field.isOk
 
 proc write*[T](writer: var CborWriter, value: Result[T, void]) {.raises: [IOError].} =
@@ -35,5 +35,5 @@ proc read*[T](
   else:
     value.ok reader.readValue(T)
 
-func isFieldExpected*[T, E](_: type[Result[T, E]]): bool {.compileTime.} =
+func isFieldExpected*[T, E](F: type Cbor, _: type[Result[T, E]]): bool {.compileTime.} =
   false

--- a/cbor_serialization/reader_desc.nim
+++ b/cbor_serialization/reader_desc.nim
@@ -104,6 +104,9 @@ func raiseIncompleteObject*(
   ex.objectType = objectType
   raise ex
 
+template raiseIncompleteObject*(r: CborReader, objectType: cstring) =
+  raiseIncompleteObject(r.parser, objectType)
+
 proc init*(
     T: type CborParser,
     stream: InputStream,

--- a/cbor_serialization/reader_impl.nim
+++ b/cbor_serialization/reader_impl.nim
@@ -61,7 +61,9 @@ func totalExpectedFields*(T: type): int {.compileTime.} =
     if isFieldExpected(Cbor, FieldType):
       inc result
 
-func expectedFieldsBitmask*(F: type Cbor, TT: type, fields: static int): auto {.compileTime.} =
+func expectedFieldsBitmask*(
+    F: type Cbor, TT: type, fields: static int
+): auto {.compileTime.} =
   type T = TT
 
   mixin isFieldExpected, enumAllSerializedFields

--- a/cbor_serialization/reader_impl.nim
+++ b/cbor_serialization/reader_impl.nim
@@ -51,17 +51,17 @@ func isBitwiseSubsetOf[N](lhs, rhs: array[N, uint]): bool =
 
   true
 
-func isFieldExpected*(T: type): bool {.compileTime.} =
+func isFieldExpected*(F: type Cbor, T: type): bool {.compileTime.} =
   T isnot Option
 
 func totalExpectedFields*(T: type): int {.compileTime.} =
   mixin isFieldExpected, enumAllSerializedFields
 
   enumAllSerializedFields(T):
-    if isFieldExpected(FieldType):
+    if isFieldExpected(Cbor, FieldType):
       inc result
 
-func expectedFieldsBitmask*(TT: type, fields: static int): auto {.compileTime.} =
+func expectedFieldsBitmask*(F: type Cbor, TT: type, fields: static int): auto {.compileTime.} =
   type T = TT
 
   mixin isFieldExpected, enumAllSerializedFields
@@ -72,7 +72,7 @@ func expectedFieldsBitmask*(TT: type, fields: static int): auto {.compileTime.} 
 
   var i = 0
   enumAllSerializedFields(T):
-    if isFieldExpected(FieldType):
+    if isFieldExpected(F, FieldType):
       res[i div bitsPerWord].setBitInWord(i mod bitsPerWord)
     inc i
 
@@ -91,7 +91,7 @@ proc read*[T: object](
     typeName = typetraits.name(T)
 
   when fieldsTable.len > 0:
-    const expectedFields = T.expectedFieldsBitmask(fieldsTable.len)
+    const expectedFields = Cbor.expectedFieldsBitmask(T, fieldsTable.len)
 
     var
       encounteredFields: typeof(expectedFields)

--- a/cbor_serialization/std/options.nim
+++ b/cbor_serialization/std/options.nim
@@ -12,7 +12,7 @@
 import std/options, ../../cbor_serialization/[reader, writer]
 export options
 
-template shouldWriteObjectField*(field: Option): bool =
+template shouldWriteObjectField*(F: type Cbor, field: Option): bool =
   field.isSome
 
 proc write*(writer: var CborWriter, value: Option) {.raises: [IOError].} =

--- a/cbor_serialization/writer.nim
+++ b/cbor_serialization/writer.nim
@@ -44,7 +44,7 @@ func init*(W: type CborWriter, stream: OutputStream): W =
   ## managed by the stream itself.
   W(stream: stream)
 
-template shouldWriteObjectField*[FieldType](field: FieldType): bool =
+template shouldWriteObjectField*[FieldType](F: type Cbor, field: FieldType): bool =
   ## Template to determine if an object field should be written.
   ## Called when `omitsOptionalField` is enabled - the field is omitted if the
   ## template returns `false`.
@@ -346,7 +346,7 @@ template shouldWriteValue(w: CborWriter, value: untyped): bool =
   type Flavor = w.Flavor
 
   when flavorOmitsOptionalFields(Flavor):
-    shouldWriteObjectField(value)
+    shouldWriteObjectField(Cbor, value)
   else:
     true
 

--- a/cbor_serialization/writer.nim
+++ b/cbor_serialization/writer.nim
@@ -442,9 +442,6 @@ proc write*(w: var CborWriter, value: CborNumber) {.raises: [IOError].} =
     else:
       w.writeHead(CborMajor.Unsigned, value.integer)
 
-proc writeValue*(w: var CborWriter, value: CborNumber) {.raises: [IOError].} =
-  w.write(value)
-
 proc write*(w: var CborWriter, value: CborObjectType) {.raises: [IOError].} =
   var fieldCount = 0
   for _, v in value:

--- a/tests/test_serialization.nim
+++ b/tests/test_serialization.nim
@@ -764,7 +764,7 @@ suite "toCbor tests":
 
   test "Result Opt types":
     check:
-      false == static(isFieldExpected Opt[Simple])
+      false == static(isFieldExpected(Cbor, Opt[Simple]))
       2 == static(HoldsResultOpt.totalSerializedFields)
       1 == static(HoldsResultOpt.totalExpectedFields)
 


### PR DESCRIPTION
I found mixins clash with the ones defined in nim-json-ser if they happen to be named the same. One way to disambiguate these is by adding `type Cbor` as first parameter. This has no downsides compared to the statu-quo.  It would be nice to pass a flavor instead of Cbor, so we could get rid of things like `flavorOmitsOptionalFields`, but then how to define a mixin that covers format+flavors like `cbor/pkg/results` requires. Passing `type CborWrite/Read` would fix it (can override `CborWrite[T]` for any flavor and `CborWrite[MyFlavor]` for MyFlavor), but then when/if moving these to nim-serialization it's back to potential ambiguity errors since the param will need to be `type` or `type object`, like it's already the case for mixins there.

This library does support to set a custom format (not flavor), and then it's odd to define funcs with `type Cbor` that will be used for such format; assuming we want to support this case. The alternative is to prefix the func names with `cbor` but that seems worse. Passing the format type does not work either, since there is no way to get a format from a flavor, and even if there would be, DefaultFlavor is the default for any format, so cannot be solved this way (cannot use `type MyCustomFormat`).

Changes:

- `shouldWriteObjectField*[FieldType](field: FieldType)` -> `shouldWriteObjectField*[FieldType](F: type Cbor, field: FieldType)`
- `expectedFieldsBitmask*(TT: type, fields: static int)` -> `expectedFieldsBitmask*(F: type Cbor, TT: type, fields: static int)`
- `isFieldExpected*(T: type)` -> `isFieldExpected*(F: type Cbor, T: type)`

The above is a "breaking change" (mixins are undocumented, but still).
