### PR TITLE
Add writeValue/readValue to std and pkg serializers

### DIFF
--- a/cbor_serialization/format.nim
+++ b/cbor_serialization/format.nim
@@ -78,6 +78,7 @@ template defaultBuiltinWriter*(Flavor: type) =
   Flavor.defaultWriter(CborValueRef)
   Flavor.defaultWriter(CborSimpleValue)
   Flavor.defaultWriter(CborBytes)
+  Flavor.defaultWriter(CborObjectType)
 
 template defaultBuiltinSerialization*(Flavor: type) =
   defaultBuiltinReader(Flavor)

--- a/cbor_serialization/pkg/bigints.nim
+++ b/cbor_serialization/pkg/bigints.nim
@@ -39,7 +39,7 @@ func toBytes(bint: BigInt, bytes: var seq[byte]) {.raises: [].} =
 const unsignedTag = 2
 const negativeTag = 3
 
-proc writeImpl*(writer: var CborWriter, value: BigInt) {.raises: [IOError].} =
+proc write*(writer: var CborWriter, value: BigInt) {.raises: [IOError].} =
   # https://www.rfc-editor.org/rfc/rfc8949#section-4.1
   if value >= 0.initBigInt:
     let sint = toInt[uint64](value)
@@ -60,7 +60,7 @@ proc writeImpl*(writer: var CborWriter, value: BigInt) {.raises: [IOError].} =
       toBytes(bint, bintTag.val)
       writer.write(bintTag)
 
-proc readImpl*(
+proc read*(
     reader: var CborReader, value: var BigInt
 ) {.raises: [IOError, SerializationError].} =
   template p(): untyped =
@@ -101,13 +101,7 @@ proc readImpl*(
     reader.parser.raiseUnexpectedValue("number", $kind)
 
 template writeValue*(writer: var CborWriter, value: BigInt) =
-  writeImpl(writer, value)
+  write(writer, value)
 
 template readValue*(reader: var CborReader, value: var BigInt) =
-  readImpl(reader, value)
-
-template write*(writer: var CborWriter, value: BigInt) =
-  writeImpl(writer, value)
-
-template read*(reader: var CborReader, value: var BigInt) =
-  readImpl(reader, value)
+  read(reader, value)

--- a/cbor_serialization/pkg/bigints.nim
+++ b/cbor_serialization/pkg/bigints.nim
@@ -39,7 +39,7 @@ func toBytes(bint: BigInt, bytes: var seq[byte]) {.raises: [].} =
 const unsignedTag = 2
 const negativeTag = 3
 
-proc write*(writer: var CborWriter, value: BigInt) {.raises: [IOError].} =
+proc writeImpl*(writer: var CborWriter, value: BigInt) {.raises: [IOError].} =
   # https://www.rfc-editor.org/rfc/rfc8949#section-4.1
   if value >= 0.initBigInt:
     let sint = toInt[uint64](value)
@@ -60,7 +60,7 @@ proc write*(writer: var CborWriter, value: BigInt) {.raises: [IOError].} =
       toBytes(bint, bintTag.val)
       writer.write(bintTag)
 
-proc read*(
+proc readImpl*(
     reader: var CborReader, value: var BigInt
 ) {.raises: [IOError, SerializationError].} =
   template p(): untyped =
@@ -99,3 +99,15 @@ proc read*(
       value *= -1.initBigInt
   else:
     reader.parser.raiseUnexpectedValue("number", $kind)
+
+template writeValue*(writer: var CborWriter, value: BigInt) =
+  writeImpl(writer, value)
+
+template readValue*(reader: var CborReader, value: var BigInt) =
+  readImpl(reader, value)
+
+template write*(writer: var CborWriter, value: BigInt) =
+  writeImpl(writer, value)
+
+template read*(reader: var CborReader, value: var BigInt) =
+  readImpl(reader, value)

--- a/cbor_serialization/pkg/results.nim
+++ b/cbor_serialization/pkg/results.nim
@@ -19,7 +19,7 @@ template shouldWriteObjectField*[T](F: type Cbor, field: Result[T, void]): bool 
 func isFieldExpected*[T, E](F: type Cbor, _: type[Result[T, E]]): bool {.compileTime.} =
   false
 
-proc writeImpl[T](writer: var CborWriter, value: Result[T, void]) {.raises: [IOError].} =
+proc write*[T](writer: var CborWriter, value: Result[T, void]) {.raises: [IOError].} =
   mixin writeValue
 
   if value.isOk:
@@ -27,7 +27,7 @@ proc writeImpl[T](writer: var CborWriter, value: Result[T, void]) {.raises: [IOE
   else:
     writer.writeValue cborNull
 
-proc readImpl[T](
+proc read*[T](
     reader: var CborReader, value: var Result[T, void]
 ) {.raises: [IOError, SerializationError].} =
   mixin readValue
@@ -39,13 +39,7 @@ proc readImpl[T](
     value.ok reader.readValue(T)
 
 template writeValue*[T](writer: var CborWriter, value: Result[T, void]) =
-  writeImpl(writer, value)
+  write(writer, value)
 
 template readValue*[T](reader: var CborReader, value: var Result[T, void]) =
-  readImpl(reader, value)
-
-template write*[T](writer: var CborWriter, value: Result[T, void]) =
-  writeImpl(writer, value)
-
-template read*[T](reader: var CborReader, value: var Result[T, void]) =
-  readImpl(reader, value)
+  read(reader, value)

--- a/cbor_serialization/pkg/results.nim
+++ b/cbor_serialization/pkg/results.nim
@@ -16,7 +16,10 @@ export results
 template shouldWriteObjectField*[T](F: type Cbor, field: Result[T, void]): bool =
   field.isOk
 
-proc write*[T](writer: var CborWriter, value: Result[T, void]) {.raises: [IOError].} =
+func isFieldExpected*[T, E](F: type Cbor, _: type[Result[T, E]]): bool {.compileTime.} =
+  false
+
+proc writeImpl[T](writer: var CborWriter, value: Result[T, void]) {.raises: [IOError].} =
   mixin writeValue
 
   if value.isOk:
@@ -24,7 +27,7 @@ proc write*[T](writer: var CborWriter, value: Result[T, void]) {.raises: [IOErro
   else:
     writer.writeValue cborNull
 
-proc read*[T](
+proc readImpl[T](
     reader: var CborReader, value: var Result[T, void]
 ) {.raises: [IOError, SerializationError].} =
   mixin readValue
@@ -35,5 +38,14 @@ proc read*[T](
   else:
     value.ok reader.readValue(T)
 
-func isFieldExpected*[T, E](F: type Cbor, _: type[Result[T, E]]): bool {.compileTime.} =
-  false
+template writeValue*[T](writer: var CborWriter, value: Result[T, void]) =
+  writeImpl(writer, value)
+
+template readValue*[T](reader: var CborReader, value: var Result[T, void]) =
+  readImpl(reader, value)
+
+template write*[T](writer: var CborWriter, value: Result[T, void]) =
+  writeImpl(writer, value)
+
+template read*[T](reader: var CborReader, value: var Result[T, void]) =
+  readImpl(reader, value)

--- a/cbor_serialization/std/net.nim
+++ b/cbor_serialization/std/net.nim
@@ -13,11 +13,11 @@ import std/[net, strutils], chronos/transports/common, ../../cbor_serialization
 
 export net, common
 
-proc write*(writer: var CborWriter, value: IpAddress) {.raises: [IOError].} =
+proc writeValue*(writer: var CborWriter, value: IpAddress) {.raises: [IOError].} =
   mixin writeValue
   writeValue(writer, $value)
 
-proc read*(reader: var CborReader, value: var IpAddress) =
+proc readValue*(reader: var CborReader, value: var IpAddress) =
   mixin readValue
   let s = reader.readValue(string)
   try:
@@ -25,18 +25,36 @@ proc read*(reader: var CborReader, value: var IpAddress) =
   except CatchableError:
     raiseUnexpectedValue(reader, "Invalid IP address")
 
-proc write*(writer: var CborWriter, value: Port) {.raises: [IOError].} =
+proc writeValue*(writer: var CborWriter, value: Port) {.raises: [IOError].} =
   mixin writeValue
   writeValue(writer, uint16 value)
 
-proc read*(reader: var CborReader, value: var Port) =
+proc readValue*(reader: var CborReader, value: var Port) =
   mixin readValue
   value = Port reader.readValue(uint16)
 
-proc write*(writer: var CborWriter, value: AddressFamily) {.raises: [IOError].} =
+proc writeValue*(writer: var CborWriter, value: AddressFamily) {.raises: [IOError].} =
   mixin writeValue
   writeValue(writer, $value)
 
-proc read*(reader: var CborReader, value: var AddressFamily) =
+proc readValue*(reader: var CborReader, value: var AddressFamily) =
   mixin readValue
   value = parseEnum[AddressFamily](reader.readValue(string))
+
+template write*(writer: var CborWriter, value: IpAddress) =
+  writeValue(writer, value)
+
+template read*(reader: var CborReader, value: var IpAddress) =
+  readValue(reader, value)
+
+template write*(writer: var CborWriter, value: Port) =
+  writeValue(writer, value)
+
+template read*(reader: var CborReader, value: var Port) =
+  readValue(reader, value)
+
+template write*(writer: var CborWriter, value: AddressFamily) =
+  writeValue(writer, value)
+
+template read*(reader: var CborReader, value: var AddressFamily) =
+  readValue(reader, value)

--- a/cbor_serialization/std/net.nim
+++ b/cbor_serialization/std/net.nim
@@ -13,11 +13,11 @@ import std/[net, strutils], chronos/transports/common, ../../cbor_serialization
 
 export net, common
 
-proc writeValue*(writer: var CborWriter, value: IpAddress) {.raises: [IOError].} =
+proc write*(writer: var CborWriter, value: IpAddress) {.raises: [IOError].} =
   mixin writeValue
   writeValue(writer, $value)
 
-proc readValue*(reader: var CborReader, value: var IpAddress) =
+proc read*(reader: var CborReader, value: var IpAddress) =
   mixin readValue
   let s = reader.readValue(string)
   try:
@@ -25,36 +25,36 @@ proc readValue*(reader: var CborReader, value: var IpAddress) =
   except CatchableError:
     raiseUnexpectedValue(reader, "Invalid IP address")
 
-proc writeValue*(writer: var CborWriter, value: Port) {.raises: [IOError].} =
+proc write*(writer: var CborWriter, value: Port) {.raises: [IOError].} =
   mixin writeValue
   writeValue(writer, uint16 value)
 
-proc readValue*(reader: var CborReader, value: var Port) =
+proc read*(reader: var CborReader, value: var Port) =
   mixin readValue
   value = Port reader.readValue(uint16)
 
-proc writeValue*(writer: var CborWriter, value: AddressFamily) {.raises: [IOError].} =
+proc write*(writer: var CborWriter, value: AddressFamily) {.raises: [IOError].} =
   mixin writeValue
   writeValue(writer, $value)
 
-proc readValue*(reader: var CborReader, value: var AddressFamily) =
+proc read*(reader: var CborReader, value: var AddressFamily) =
   mixin readValue
   value = parseEnum[AddressFamily](reader.readValue(string))
 
-template write*(writer: var CborWriter, value: IpAddress) =
-  writeValue(writer, value)
+template writeValue*(writer: var CborWriter, value: IpAddress) =
+  write(writer, value)
 
-template read*(reader: var CborReader, value: var IpAddress) =
-  readValue(reader, value)
+template readValue*(reader: var CborReader, value: var IpAddress) =
+  read(reader, value)
 
-template write*(writer: var CborWriter, value: Port) =
-  writeValue(writer, value)
+template writeValue*(writer: var CborWriter, value: Port) =
+  write(writer, value)
 
-template read*(reader: var CborReader, value: var Port) =
-  readValue(reader, value)
+template readValue*(reader: var CborReader, value: var Port) =
+  read(reader, value)
 
-template write*(writer: var CborWriter, value: AddressFamily) =
-  writeValue(writer, value)
+template writeValue*(writer: var CborWriter, value: AddressFamily) =
+  write(writer, value)
 
-template read*(reader: var CborReader, value: var AddressFamily) =
-  readValue(reader, value)
+template readValue*(reader: var CborReader, value: var AddressFamily) =
+  read(reader, value)

--- a/cbor_serialization/std/options.nim
+++ b/cbor_serialization/std/options.nim
@@ -15,7 +15,7 @@ export options
 template shouldWriteObjectField*(F: type Cbor, field: Option): bool =
   field.isSome
 
-proc write*(writer: var CborWriter, value: Option) {.raises: [IOError].} =
+proc writeValue*(writer: var CborWriter, value: Option) {.raises: [IOError].} =
   mixin writeValue
 
   if value.isSome:
@@ -23,7 +23,7 @@ proc write*(writer: var CborWriter, value: Option) {.raises: [IOError].} =
   else:
     writer.writeValue cborNull
 
-proc read*[T](
+proc readValue*[T](
     reader: var CborReader, value: var Option[T]
 ) {.raises: [IOError, SerializationError].} =
   mixin readValue
@@ -33,3 +33,9 @@ proc read*[T](
     discard reader.parseSimpleValue()
   else:
     value = some reader.readValue(T)
+
+template write*(writer: var CborWriter, value: Option) =
+  writeValue(writer, value)
+
+template read*[T](reader: var CborReader, value: var Option[T]) =
+  readValue(reader, value)

--- a/cbor_serialization/std/options.nim
+++ b/cbor_serialization/std/options.nim
@@ -15,7 +15,7 @@ export options
 template shouldWriteObjectField*(F: type Cbor, field: Option): bool =
   field.isSome
 
-proc writeValue*(writer: var CborWriter, value: Option) {.raises: [IOError].} =
+proc write*(writer: var CborWriter, value: Option) {.raises: [IOError].} =
   mixin writeValue
 
   if value.isSome:
@@ -23,7 +23,7 @@ proc writeValue*(writer: var CborWriter, value: Option) {.raises: [IOError].} =
   else:
     writer.writeValue cborNull
 
-proc readValue*[T](
+proc read*[T](
     reader: var CborReader, value: var Option[T]
 ) {.raises: [IOError, SerializationError].} =
   mixin readValue
@@ -34,8 +34,8 @@ proc readValue*[T](
   else:
     value = some reader.readValue(T)
 
-template write*(writer: var CborWriter, value: Option) =
-  writeValue(writer, value)
+template writeValue*(writer: var CborWriter, value: Option) =
+  write(writer, value)
 
-template read*[T](reader: var CborReader, value: var Option[T]) =
-  readValue(reader, value)
+template readValue*[T](reader: var CborReader, value: var Option[T]) =
+  read(reader, value)

--- a/cbor_serialization/std/sets.nim
+++ b/cbor_serialization/std/sets.nim
@@ -25,6 +25,12 @@ proc readImpl(
   for elem in readArray(reader, ElemType):
     value.incl elem
 
+template writeValue*(writer: var CborWriter, value: SetType) =
+  writeImpl(writer, value)
+
+template readValue*(reader: var CborReader, value: var SetType) =
+  readImpl(reader, value)
+
 # TODO: https://github.com/nim-lang/Nim/issues/25174
 
 template write*(writer: var CborWriter, value: OrderedSet) =
@@ -45,4 +51,4 @@ template read*(reader: var CborReader, value: var HashSet) =
 template read*(reader: var CborReader, value: var set) =
   readImpl(reader, value)
 
-Cbor.defaultSerialization(set)
+#Cbor.defaultSerialization(set)

--- a/cbor_serialization/std/tables.nim
+++ b/cbor_serialization/std/tables.nim
@@ -15,7 +15,7 @@ export tables
 
 type TableType = OrderedTable | Table
 
-proc writeImpl(writer: var CborWriter, value: TableType) {.raises: [IOError].} =
+proc writeValue*(writer: var CborWriter, value: TableType) {.raises: [IOError].} =
   writer.beginObject()
   for key, val in value:
     writer.writeField $key, val
@@ -33,7 +33,7 @@ template to*(a: string, b: type float): float =
 template to*(a: string, b: type string): string =
   a
 
-proc readImpl(
+proc readValue*(
     reader: var CborReader, value: var TableType
 ) {.raises: [IOError, SerializationError].} =
   try:
@@ -48,13 +48,13 @@ proc readImpl(
 # TODO: https://github.com/nim-lang/Nim/issues/25174
 
 template write*(writer: var CborWriter, value: OrderedTable) =
-  writeImpl(writer, value)
+  writeValue(writer, value)
 
 template write*(writer: var CborWriter, value: Table) =
-  writeImpl(writer, value)
+  writeValue(writer, value)
 
 template read*(reader: var CborReader, value: var OrderedTable) =
-  readImpl(reader, value)
+  readValue(reader, value)
 
 template read*(reader: var CborReader, value: var Table) =
-  readImpl(reader, value)
+  readValue(reader, value)

--- a/cbor_serialization/std/tables.nim
+++ b/cbor_serialization/std/tables.nim
@@ -15,7 +15,7 @@ export tables
 
 type TableType = OrderedTable | Table
 
-proc writeValue*(writer: var CborWriter, value: TableType) {.raises: [IOError].} =
+proc writeImpl(writer: var CborWriter, value: TableType) {.raises: [IOError].} =
   writer.beginObject()
   for key, val in value:
     writer.writeField $key, val
@@ -33,7 +33,7 @@ template to*(a: string, b: type float): float =
 template to*(a: string, b: type string): string =
   a
 
-proc readValue*(
+proc readImpl(
     reader: var CborReader, value: var TableType
 ) {.raises: [IOError, SerializationError].} =
   try:
@@ -45,16 +45,22 @@ proc readValue*(
   except ValueError as ex:
     reader.raiseUnexpectedValue("TableType: " & ex.msg)
 
+template writeValue*(writer: var CborWriter, value: TableType) =
+  writeImpl(writer, value)
+
+template readValue*(reader: var CborReader, value: var TableType) =
+  readImpl(reader, value)
+
 # TODO: https://github.com/nim-lang/Nim/issues/25174
 
 template write*(writer: var CborWriter, value: OrderedTable) =
-  writeValue(writer, value)
+  writeImpl(writer, value)
 
 template write*(writer: var CborWriter, value: Table) =
-  writeValue(writer, value)
+  writeImpl(writer, value)
 
 template read*(reader: var CborReader, value: var OrderedTable) =
-  readValue(reader, value)
+  readImpl(reader, value)
 
 template read*(reader: var CborReader, value: var Table) =
-  readValue(reader, value)
+  readImpl(reader, value)

--- a/tests/test_cbor_flavor.nim
+++ b/tests/test_cbor_flavor.nim
@@ -63,8 +63,8 @@ type
 StringyCbor.defaultSerialization Container
 
 createCborFlavor OptCbor
-OptCbor.defaultSerialization Result
-OptCbor.defaultSerialization Option
+#OptCbor.defaultSerialization Result
+#OptCbor.defaultSerialization Option
 OptCbor.defaultSerialization OptionalFields
 
 #{


### PR DESCRIPTION
Currently, if the user does `defaultSerialization(flavor, T)` where `T` is a type in std/pkg modules, and they forget to actually import such module (or remove the import later by mistake), the default serialization will use the `object` one (if T is an object), which if lucky will throw a comptime error (or worse it will serialize the value giving an incorrect encoded output). This PR fixes this by not making `defaultSerialization` needed for std/pkg modules.

The `write*` and `read*` procs are still needed when the flavor/format has `defaultSerialization(flavor, object)`, so the generated code will call these functions, as the generated readValue/writeValue match harder than the readValue/writeValue this PR adds.

Changes:

- Add `writeValue` and `readValue` to the `std` and `pkg` modules. This makes it so `defaultSerialization` is no longer needed to enable these.

This seems backward compatible.

~~Edit: the problem is really `defaultSerialization(flavor, object)` which enables a default serialization for any object, maybe the solution is for flavors to not enable it which is already the case in usage I've seen... and the current behavior makes sense... it could just be documented... mmh~~ Still something like defaultSerialization(flavor, Table) will use the default serialization if pkg/tables not imported.

Edit2: a different way of solving this is to add an additional `defaultSerialization` that accepts a module name, and then calls `module.write/read`. Alternatively, add a `extensionSerialization` that calls some alias for read/write defined in std/pkg modules. Either is an addition non-breaking change.

Ref #2