### PR TITLE
JSON to CBOR converter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         nimble list --installed --version
         env NIMLANG=c nimble test
         env NIMLANG=cpp nimble test
-        env nimble --useSystemNim install -y --depsonly json_serialization, bigints
+        env nimble --useSystemNim install -y --depsonly json_serialization bigints
         env nimble examples
         env NIMLANG=c nimble test_dev
         env NIMLANG=cpp nimble test_dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         nimble list --installed --version
         env NIMLANG=c nimble test
         env NIMLANG=cpp nimble test
-        env nimble examples
         env nimble --useSystemNim install -y --depsonly json_serialization, bigints
+        env nimble examples
         env NIMLANG=c nimble test_dev
         env NIMLANG=cpp nimble test_dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
       test-command: |
         nimble dump --solve
         nimble list --installed --version
-        env nimble features
         env NIMLANG=c nimble test
         env NIMLANG=cpp nimble test
         env nimble examples
+        env nimble --useSystemNim install -y --depsonly json_serialization, bigints
+        env NIMLANG=c nimble test_dev
+        env NIMLANG=cpp nimble test_dev

--- a/cbor_serialization.nimble
+++ b/cbor_serialization.nimble
@@ -19,16 +19,16 @@ skipDirs = @["tests", "fuzzer"]
 requires "nim >= 2.0.0",
   "serialization >= 0.4.9", "stew >= 0.4.1", "npeg >= 1.3.0", "results", "unittest2"
 
-#feature "bigints":
-#  require "bigints"
+#feature "dev":
+#  requires "bigints", "json_serialization"
+
+from os import quoteShell
+from strutils import endsWith
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)
 let flags = getEnv("NIMFLAGS", "") # Extra flags for the compiler
 let verbose = getEnv("V", "") notin ["", "0"]
-
-from os import quoteShell
-from strutils import endsWith
 
 let cfg =
   " --styleCheck:usages --styleCheck:error" &
@@ -47,6 +47,10 @@ task test, "Run all tests":
   for threads in ["--threads:off", "--threads:on"]:
     run threads, "tests/test_all"
 
+task test_dev, "Run all dev tests":
+  for threads in ["--threads:off", "--threads:on"]:
+    run threads, "tests/test_all_dev"
+
 task examples, "Run examples":
   # Run book examples
   for file in listFiles("docs/examples"):
@@ -57,6 +61,3 @@ task docs, "Generate API documentation":
   exec "mdbook build docs"
   exec nimc & " doc " &
     "--git.url:https://github.com/vacp2p/nim-cbor-serialization --git.commit:master --outdir:docs/book/api --project cbor_serialization"
-
-task features, "Install all features":
-  exec "nimble install bigints -y"

--- a/cbor_serialization/json_utils.nim
+++ b/cbor_serialization/json_utils.nim
@@ -1,0 +1,151 @@
+# cbor-serialization
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [], gcsafe.}
+
+import
+  std/[math, strutils],
+  stew/[base64, byteutils],
+  json_serialization,
+  ./[reader, writer]
+
+export JsonString, CborBytes, SerializationError
+
+# https://www.rfc-editor.org/rfc/rfc8949.html#section-6.1
+proc writeToJson*(
+    reader: var CborReader, writer: var JsonWriter, substitute = true
+) {.raises: [IOError, SerializationError].} =
+  mixin writeValue, readValue
+  template p(): untyped =
+    reader.parser
+
+  template substituteOrRaise(msg: string): untyped =
+    if substitute:
+      writer.writeValue JsonString("null")
+    else:
+      p.raiseUnexpectedValue(msg)
+
+  case p.cborKind()
+  of CborValueKind.Bytes:
+    writer.writeValue(Base64Url.encode(reader.readValue(seq[byte])))
+  of CborValueKind.String:
+    writer.writeValue(reader.readValue(string))
+  of CborValueKind.Unsigned:
+    writer.writeValue(reader.readValue(uint64))
+  of CborValueKind.Negative:
+    writer.writeValue(reader.readValue(int64))
+  of CborValueKind.Float:
+    let f = reader.readValue(float64)
+    case f.classify
+    of fcNan:
+      substituteOrRaise("Nan float")
+    of fcInf:
+      substituteOrRaise("Positive infinity float")
+    of fcNegInf:
+      substituteOrRaise("Negative infinity float")
+    else:
+      writer.writeValue(f)
+  of CborValueKind.Object:
+    writeObject(writer):
+      parseObject(reader, key):
+        writer.writeName(key)
+        writeToJson(reader, writer)
+  of CborValueKind.Array:
+    writeArray(writer):
+      parseArray(reader):
+        writeToJson(reader, writer)
+  of CborValueKind.Tag:
+    var tag: uint64
+    parseTag(reader, tag):
+      case tag
+      of 2, 21:
+        writer.writeValue(Base64Url.encode(reader.readValue(seq[byte])))
+      of 3:
+        writer.writeValue("~" & Base64Url.encode(reader.readValue(seq[byte])))
+      of 22:
+        writer.writeValue(Base64.encode(reader.readValue(seq[byte])))
+      of 23:
+        writer.writeValue("0x" & toUpperAscii(toHex(reader.readValue(seq[byte]))))
+      else:
+        writeToJson(reader, writer)
+  of CborValueKind.Simple:
+    let val = reader.readValue(CborSimpleValue)
+    substituteOrRaise($val)
+  of CborValueKind.Bool:
+    writer.writeValue(reader.readValue(bool))
+  of CborValueKind.Null:
+    let _ = reader.readValue(CborSimpleValue)
+    writer.writeValue JsonString("null")
+  of CborValueKind.Undefined:
+    let _ = reader.readValue(CborSimpleValue)
+    substituteOrRaise("undefined")
+
+proc toJson*(
+    cbor: CborBytes, substitute = true, pretty = false
+): string {.raises: [SerializationError].} =
+  var cborStream = unsafeMemoryInput(seq[byte](cbor))
+  var reader = CborReader[DefaultFlavor].init(cborStream)
+  var jsonStream = memoryOutput()
+  var writer = JsonWriter[DefaultFlavor].init(jsonStream, pretty)
+  try:
+    reader.writeToJson(writer, substitute)
+  except IOError:
+    raiseAssert "memoryOutput is exception-free"
+  jsonStream.getOutput(string)
+
+# https://www.rfc-editor.org/rfc/rfc8949.html#section-6.2
+proc writeToCbor*(
+    reader: var JsonReader, writer: var CborWriter
+) {.raises: [IOError, SerializationError].} =
+  mixin writeValue, readValue
+
+  case reader.tokKind
+  of JsonValueKind.String:
+    writer.writeValue(reader.readValue(string))
+  of JsonValueKind.Number:
+    let num = reader.readValue(JsonNumber[uint64])
+    if num.isFloat():
+      writer.writeValue(reader.toFloat(num, float64))
+    elif num.sign == JsonSign.Neg:
+      writer.writeValue(reader.toInt(num, int64, portable = false))
+    else:
+      writer.writeValue(reader.toInt(num, uint64, portable = false))
+  of JsonValueKind.Object:
+    writeObject(writer):
+      parseObjectWithoutSkip(reader, key):
+        writer.writeName(key)
+        writeToCbor(reader, writer)
+  of JsonValueKind.Array:
+    writeArray(writer):
+      parseArray(reader):
+        writeToCbor(reader, writer)
+  of JsonValueKind.Bool:
+    writer.writeValue(reader.readValue(bool))
+  of JsonValueKind.Null:
+    reader.parseNull()
+    writer.writeValue(cborNull)
+
+proc toCbor*(
+    json: JsonString, definiteLen = false
+): seq[byte] {.raises: [SerializationError].} =
+  var jsonStream = unsafeMemoryInput(string(json))
+  var reader = JsonReader[DefaultFlavor].init(jsonStream)
+  var cborStream = memoryOutput()
+  var writer = CborWriter[DefaultFlavor].init(cborStream)
+  try:
+    reader.writeToCbor(writer)
+  except IOError:
+    raiseAssert "memoryOutput is exception-free"
+  if definiteLen:
+    # XXX writeToCbor writes map/array as streams (indefinite length);
+    #     decode-encode dance will convert indefinite to definite length;
+    #     implement definiteLen mode in writeObject/Array to avoid this
+    Cbor.encode(Cbor.decode(cborStream.getOutput(seq[byte]), CborValueRef))
+  else:
+    cborStream.getOutput(seq[byte])

--- a/cbor_serialization/json_utils.nim
+++ b/cbor_serialization/json_utils.nim
@@ -10,10 +10,7 @@
 {.push raises: [], gcsafe.}
 
 import
-  std/[math, strutils],
-  stew/[base64, byteutils],
-  json_serialization,
-  ./[reader, writer]
+  std/[math, strutils], stew/[base64, byteutils], json_serialization, ./[reader, writer]
 
 export JsonString, CborBytes, SerializationError
 

--- a/cbor_serialization/json_utils.nim
+++ b/cbor_serialization/json_utils.nim
@@ -28,6 +28,12 @@ proc writeToJson*(
     else:
       p.raiseUnexpectedValue(msg)
 
+  template readAsJson(reader: untyped): string =
+    var outTmp = memoryOutput()
+    var writerTmp = JsonWriter.init(outTmp)
+    writeToJson(reader, writerTmp)
+    outTmp.getOutput(string)
+
   case p.cborKind()
   of CborValueKind.Bytes:
     writer.writeValue(Base64Url.encode(reader.readValue(seq[byte])))
@@ -50,8 +56,26 @@ proc writeToJson*(
       writer.writeValue(f)
   of CborValueKind.Object:
     writeObject(writer):
-      parseObject(reader, key):
+      parseObjectCustomKey(reader):
+        let key =
+          case p.cborKind()
+          of CborValueKind.String:
+            reader.readValue(string)
+          of CborValueKind.Tag:
+            var val: string
+            var tag: uint64
+            parseTag(reader, tag):
+              val =
+                case p.cborKind()
+                of CborValueKind.String:
+                  reader.readValue(string)
+                else:
+                  reader.readAsJson()
+            val
+          else:
+            reader.readAsJson()
         writer.writeName(key)
+      do:
         writeToJson(reader, writer)
   of CborValueKind.Array:
     writeArray(writer):

--- a/docs/examples/json0.nim
+++ b/docs/examples/json0.nim
@@ -6,7 +6,7 @@ import cbor_serialization, cbor_serialization/json_utils
 
 # ANCHOR: json
 let jsonDecoded = """{"cborrpc":"2.0","method":"subtract","params":[42,3],"id":1}"""
-# ANCHOR: json
+# ANCHOR_END: json
 
 # ANCHOR: toCbor
 let encoded = toCbor(jsonDecoded.JsonString)

--- a/docs/examples/json0.nim
+++ b/docs/examples/json0.nim
@@ -1,0 +1,17 @@
+{.push gcsafe, raises: [].}
+
+# ANCHOR: Import
+import cbor_serialization, cbor_serialization/json_utils
+# ANCHOR_END: Import
+
+# ANCHOR: json
+let jsonDecoded = """{"cborrpc":"2.0","method":"subtract","params":[42,3],"id":1}"""
+# ANCHOR: json
+
+# ANCHOR: toCbor
+let encoded = toCbor(jsonDecoded.JsonString)
+# ANCHOR_END: toCbor
+
+# ANCHOR: toJson
+doAssert toJson(encoded.CborBytes) == jsonDecoded
+# ANCHOR_END: toJson

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,6 +6,7 @@
 - [Streaming](./streaming.md)
 - [CDDL](./cddl.md)
 - [Debugging](./debugging.md)
+- [JSON](./json.md)
 - [Reference](./reference.md)
 
 # Developer guide

--- a/docs/src/json.md
+++ b/docs/src/json.md
@@ -1,0 +1,54 @@
+# JSON
+
+This section provides an overview of the `cbor_serialization` json tools.
+
+## JSON to CBOR
+
+JSON can be converted to CBOR with the `toCbor(JsonString): seq[byte]` API.
+The implementation converts JSON as described in [RFC8949](https://www.rfc-editor.org/rfc/rfc8949.html#section-6.2).
+
+Requires the `json_serialization` nimble package.
+
+Import `json_utils`:
+
+```nim
+{{#include ../examples/json0.nim:Import}}
+```
+
+Encode a JSON string to CBOR bytes:
+
+```nim
+{{#include ../examples/json0.nim:json}}
+```
+
+```nim
+{{#include ../examples/json0.nim:toCbor}}
+```
+
+## CBOR to JSON
+
+CBOR can be converted to JSON with the `toJson(CborBytes): string` API.
+The implementation converts CBOR as described in [RFC8949](https://www.rfc-editor.org/rfc/rfc8949.html#section-6.1).
+
+Note some CBOR types do not have direct analogs in JSON:
+
+- NaN, -Infinity, Infinity, undefined, and simple values are converted to null.
+- `seq[byte]` is base64 encoded.
+- Tags 2, 21 and 22 are base64 encoded.
+- Tag 3 is base64 encoded and prefixed with `~`.
+- Tag 23 is hex encoded.
+- All tag numbers are lost (not encoded); only their value is encoded.
+
+Requires the `json_serialization` nimble package.
+
+Import `json_utils`:
+
+```nim
+{{#include ../examples/json0.nim:Import}}
+```
+
+Encode CBOR bytes to a JSON string:
+
+```nim
+{{#include ../examples/json0.nim:toJson}}
+```

--- a/docs/src/json.md
+++ b/docs/src/json.md
@@ -38,6 +38,7 @@ Note some CBOR types do not have direct analogs in JSON:
 - Tag 3 is base64 encoded and prefixed with `~`.
 - Tag 23 is hex encoded.
 - All tag numbers are lost (not encoded); only their value is encoded.
+- Non-string map keys are stringified using `toJson` which can create key collisions.
 
 Requires the `json_serialization` nimble package.
 

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -10,18 +10,8 @@
 {.warning[UnusedImport]: off.}
 
 import
-  test_spec, test_serialization, test_simple_value, test_cbor_flavor, test_parser,
-  test_reader, test_writer, test_valueref, test_cbor_raw, test_malformed, test_std,
-  test_overloads, test_edn, test_cddl_parser, test_cddl_gen
-
-template importBigints() =
-  import bigints
-
-#when compiles(importBigints):
-import ./test_bigints
-
-template importjson() =
-  import json_serialization
-
-#when compiles(importjson):
-import ./test_tools
+  ./[
+    test_spec, test_serialization, test_simple_value, test_cbor_flavor, test_parser,
+    test_reader, test_writer, test_valueref, test_cbor_raw, test_malformed, test_std,
+    test_overloads, test_edn, test_cddl_parser, test_cddl_gen,
+  ]

--- a/tests/test_all.nim
+++ b/tests/test_all.nim
@@ -17,5 +17,11 @@ import
 template importBigints() =
   import bigints
 
-when compiles(importBigints):
-  import test_bigints
+#when compiles(importBigints):
+import ./test_bigints
+
+template importjson() =
+  import json_serialization
+
+#when compiles(importjson):
+import ./test_tools

--- a/tests/test_all_dev.nim
+++ b/tests/test_all_dev.nim
@@ -1,0 +1,12 @@
+# cbor-serialization
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.warning[UnusedImport]: off.}
+
+import ./[test_bigints, test_json_utils]

--- a/tests/test_json_utils.nim
+++ b/tests/test_json_utils.nim
@@ -7,8 +7,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-import
-  unittest2, ../cbor_serialization, ../cbor_serialization/json_utils, ./utils
+import unittest2, ../cbor_serialization, ../cbor_serialization/json_utils, ./utils
 
 const testCases = [
   ("0x00", "0"),

--- a/tests/test_json_utils.nim
+++ b/tests/test_json_utils.nim
@@ -92,6 +92,12 @@ const testCasesNoRountrip = [
   ("0xc349010000000000000000", "\"~AQAAAAAAAAAA\""),
   ("0x40", "\"\""),
   ("0x4401020304", "\"AQIDBA\""),
+  # maps with non-string keys
+  ("0xa201020304", """{"1":2,"3":4}"""),
+  (
+    "0xa1c074323031332d30332d32315432303a30343a30305a01",
+    """{"2013-03-21T20:04:00Z":1}""",
+  ),
 ]
 
 suite "Test CBOR to JSON":

--- a/tests/test_json_utils.nim
+++ b/tests/test_json_utils.nim
@@ -1,0 +1,107 @@
+# cbor-serialization
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import
+  unittest2, ../cbor_serialization, ../cbor_serialization/json_utils, ./utils
+
+const testCases = [
+  ("0x00", "0"),
+  ("0x01", "1"),
+  ("0x0a", "10"),
+  ("0x17", "23"),
+  ("0x1818", "24"),
+  ("0x1819", "25"),
+  ("0x1864", "100"),
+  ("0x1903e8", "1000"),
+  ("0x1a000f4240", "1000000"),
+  ("0x1b000000e8d4a51000", "1000000000000"),
+  ("0x1bffffffffffffffff", "18446744073709551615"),
+  ("0x20", "-1"),
+  ("0x29", "-10"),
+  ("0x3863", "-100"),
+  ("0x3903e7", "-1000"),
+  ("0xfb3ff199999999999a", "1.1"),
+  ("0xfa47c35000", "100000.0"),
+  ("0xfbc010666666666666", "-4.1"),
+  ("0xf4", "false"),
+  ("0xf5", "true"),
+  ("0xf6", "null"),
+  ("0x60", "\"\""),
+  ("0x6161", "\"a\""),
+  ("0x6449455446", "\"IETF\""),
+  ("0x62225c", """"\"\\""""),
+  ("0x62c3bc", "\"ü\""),
+  ("0x63e6b0b4", "\"水\""),
+  ("0x64f0908591", "\"𐅑\""),
+  ("0x80", "[]"),
+  ("0x83010203", "[1,2,3]"),
+  ("0x8301820203820405", "[1,[2,3],[4,5]]"),
+  (
+    "0x98190102030405060708090a0b0c0d0e0f101112131415161718181819",
+    "[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]",
+  ),
+  ("0xa0", "{}"),
+  ("0xa26161016162820203", """{"a":1,"b":[2,3]}"""),
+  ("0x826161a161626163", """["a",{"b":"c"}]"""),
+  (
+    "0xa56161614161626142616361436164614461656145",
+    """{"a":"A","b":"B","c":"C","d":"D","e":"E"}""",
+  ),
+]
+
+const testCasesNoRountrip = [
+  # exponent too large
+  ("0xfa7f7fffff", "3.4028234663852886e+38"),
+  ("0xfb7e37e43c8800759c", "1e+300"), # 1.0e+300
+  # float16; it will encode as float32 in cbor
+  ("0xf90000", "0.0"),
+  ("0xf98000", "-0.0"),
+  ("0xf93c00", "1.0"),
+  ("0xf93e00", "1.5"),
+  ("0xf97bff", "65504.0"),
+  ("0xf90001", "5.960464477539063e-8"),
+  ("0xf90400", "0.00006103515625"),
+  ("0xf9c400", "-4.0"),
+  # substituted
+  ("0xf97c00", "null"),
+  ("0xf97e00", "null"),
+  ("0xf9fc00", "null"),
+  ("0xf7", "null"),
+  ("0xf0", "null"),
+  ("0xf8ff", "null"),
+  ("0xfa7f800000", "null"),
+  ("0xfa7fc00000", "null"),
+  ("0xfaff800000", "null"),
+  ("0xfb7ff0000000000000", "null"),
+  ("0xfb7ff8000000000000", "null"),
+  ("0xfbfff0000000000000", "null"),
+  # tags
+  ("0xc074323031332d30332d32315432303a30343a30305a", "\"2013-03-21T20:04:00Z\""),
+  ("0xc11a514b67b0", "1363896240"),
+  ("0xc1fb41d452d9ec200000", "1363896240.5"),
+  ("0xd74401020304", "\"0x01020304\""),
+  ("0xd818456449455446", "\"ZElFVEY\""),
+  ("0xd82076687474703a2f2f7777772e6578616d706c652e636f6d", "\"http://www.example.com\""),
+  # byte strings
+  ("0xc249010000000000000000", "\"AQAAAAAAAAAA\""),
+  ("0xc349010000000000000000", "\"~AQAAAAAAAAAA\""),
+  ("0x40", "\"\""),
+  ("0x4401020304", "\"AQIDBA\""),
+]
+
+suite "Test CBOR to JSON":
+  test "CBOR spec to JSON":
+    for (cbor, json) in items(testCases):
+      check toJson(CborBytes(cbor.unhex)) == json
+    for (cbor, json) in items(testCasesNoRountrip):
+      check toJson(CborBytes(cbor.unhex)) == json
+
+  test "JSON spec to CBOR":
+    for (cbor, json) in items(testCases):
+      check toCbor(JsonString(json), definiteLen = true).hex == cbor


### PR DESCRIPTION
supersedes #27 

Changes:

- Add `cbor_serialization/json_utils` module
- Add `toCbor(JsonString): seq[byte]` and `toJson(CborBytes): string` APIs
- Add docs